### PR TITLE
Closes #132 Move main method into its own class

### DIFF
--- a/src/main/java/com/neopragma/cobolcheck/Constants.java
+++ b/src/main/java/com/neopragma/cobolcheck/Constants.java
@@ -33,6 +33,9 @@ public final class Constants {
     // Cobol Check copybook location (not for users)
     public static final String COBOLCHECK_COPYBOOK_DIRECTORY = "/com/neopragma/cobolcheck/copybooks/";
 
+    //Command line options
+    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:vh --long config-file:,log-level:,programs:,tests:,version,help";
+
     // Frequently-used string values
     public static final String EMPTY_STRING = "";
     public static final String NEWLINE = System.getProperty("line.separator");

--- a/src/main/java/com/neopragma/cobolcheck/Driver.java
+++ b/src/main/java/com/neopragma/cobolcheck/Driver.java
@@ -38,7 +38,6 @@ public class Driver implements StringHelper {
     private Reader testSuite;
     private Reader cobolSourceIn;
     private Writer testSourceOut;
-    private static final String optionSpec = "c:l:p:t:vh --long config-file:,log-level:,programs:,tests:,version,help";
     private String configFileFromCommandLine = Constants.EMPTY_STRING;
     private static int exitStatus;
 
@@ -64,6 +63,11 @@ public class Driver implements StringHelper {
         Driver.messages = config.getMessages();
         this.options = options;
         exitStatus = Constants.STATUS_NORMAL;
+    }
+
+    public int getExitStatus()
+    {
+        return exitStatus;
     }
 
     void run() throws InterruptedException {
@@ -271,16 +275,5 @@ public class Driver implements StringHelper {
         for (String line : helpText) {
             System.out.println(line);
         }
-    }
-
-    public static void main(String[] args) throws InterruptedException {
-        messages = new Messages();
-        Config config = new Config(messages);
-        config.load();
-        Driver app = new Driver(
-                config,
-                new GetOpt(args, optionSpec, config));
-        app.run();
-        System.exit(exitStatus);
     }
 }

--- a/src/main/java/com/neopragma/cobolcheck/Main.java
+++ b/src/main/java/com/neopragma/cobolcheck/Main.java
@@ -1,0 +1,14 @@
+package com.neopragma.cobolcheck;
+
+class Main {
+    public static void main(String[] args) throws InterruptedException {
+        Messages messages = new Messages();
+        Config config = new Config(messages);
+        config.load();
+        Driver app = new Driver(
+                config,
+                new GetOpt(args, Constants.COMMAND_lINE_OPTIONS, config));
+        app.run();
+        System.exit(app.getExitStatus());
+    }
+}


### PR DESCRIPTION
Changes:
- Moved optionSpec from Driver to Constants and renamed it to COMMAND_lINE_OPTIONS.
- Added method; getExitStatus in Driver.
- Added class; Main.
- Moved main method from Driver to Main.