### PR TITLE
 closes #140 Divide runTestSuites method into smaller methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:15.0'
     testImplementation('org.junit.jupiter:junit-jupiter:5.6.1')
     testImplementation('org.junit.jupiter:junit-jupiter-params:5.7.0')
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'org.mockito:mockito-inline:3.6.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.6.28'
 }
 

--- a/src/main/java/com/neopragma/cobolcheck/Constants.java
+++ b/src/main/java/com/neopragma/cobolcheck/Constants.java
@@ -33,6 +33,9 @@ public final class Constants {
     // Cobol Check copybook location (not for users)
     public static final String COBOLCHECK_COPYBOOK_DIRECTORY = "/com/neopragma/cobolcheck/copybooks/";
 
+    //Command line options
+    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:vh --long config-file:,log-level:,programs:,tests:,version,help";
+
     // Frequently-used string values
     public static final String EMPTY_STRING = "";
     public static final String NEWLINE = System.getProperty("line.separator");

--- a/src/main/java/com/neopragma/cobolcheck/Driver.java
+++ b/src/main/java/com/neopragma/cobolcheck/Driver.java
@@ -38,7 +38,6 @@ public class Driver implements StringHelper {
     private Reader testSuite;
     private Reader cobolSourceIn;
     private Writer testSourceOut;
-    private static final String optionSpec = "c:l:p:t:vh --long config-file:,log-level:,programs:,tests:,version,help";
     private String configFileFromCommandLine = Constants.EMPTY_STRING;
     private static int exitStatus;
 
@@ -64,6 +63,11 @@ public class Driver implements StringHelper {
         Driver.messages = config.getMessages();
         this.options = options;
         exitStatus = Constants.STATUS_NORMAL;
+    }
+
+    public int getExitStatus()
+    {
+        return exitStatus;
     }
 
     void run() throws InterruptedException {
@@ -271,16 +275,5 @@ public class Driver implements StringHelper {
         for (String line : helpText) {
             System.out.println(line);
         }
-    }
-
-    public static void main(String[] args) throws InterruptedException {
-        messages = new Messages();
-        Config config = new Config(messages);
-        config.load();
-        Driver app = new Driver(
-                config,
-                new GetOpt(args, optionSpec, config));
-        app.run();
-        System.exit(exitStatus);
     }
 }

--- a/src/main/java/com/neopragma/cobolcheck/LinuxProcessLauncher.java
+++ b/src/main/java/com/neopragma/cobolcheck/LinuxProcessLauncher.java
@@ -29,10 +29,17 @@ public class LinuxProcessLauncher implements ProcessLauncher, StringHelper {
 
     private Config config;
     private Messages messages;
+    private String processConfigKeyPrefix;
 
-    public LinuxProcessLauncher(Config config) {
+    public LinuxProcessLauncher(Config config, String processConfigKeyPrefix) {
         this.config = config;
         this.messages = config.getMessages();
+        this.processConfigKeyPrefix = processConfigKeyPrefix;
+    }
+
+    @Override
+    public String getProcessConfigKeyPrefix() {
+        return processConfigKeyPrefix;
     }
 
     @Override

--- a/src/main/java/com/neopragma/cobolcheck/Main.java
+++ b/src/main/java/com/neopragma/cobolcheck/Main.java
@@ -1,0 +1,14 @@
+package com.neopragma.cobolcheck;
+
+class Main {
+    public static void main(String[] args) throws InterruptedException {
+        Messages messages = new Messages();
+        Config config = new Config(messages);
+        config.load();
+        Driver app = new Driver(
+                config,
+                new GetOpt(args, Constants.COMMAND_lINE_OPTIONS, config));
+        app.run();
+        System.exit(app.getExitStatus());
+    }
+}

--- a/src/main/java/com/neopragma/cobolcheck/ProcessLauncher.java
+++ b/src/main/java/com/neopragma/cobolcheck/ProcessLauncher.java
@@ -22,6 +22,8 @@ package com.neopragma.cobolcheck;
  * @since 1.5
  */
 public interface ProcessLauncher {
+    String getProcessConfigKeyPrefix();
     Process run(String programName);
+
 
 }

--- a/src/main/java/com/neopragma/cobolcheck/WindowsProcessLauncher.java
+++ b/src/main/java/com/neopragma/cobolcheck/WindowsProcessLauncher.java
@@ -29,10 +29,17 @@ public class WindowsProcessLauncher implements ProcessLauncher, StringHelper {
 
     private Config config;
     private Messages messages;
+    private String processConfigKeyPrefix;
 
-    public WindowsProcessLauncher(Config config) {
+    public WindowsProcessLauncher(Config config, String processConfigKeyPrefix) {
         this.config = config;
         this.messages = config.getMessages();
+        this.processConfigKeyPrefix = processConfigKeyPrefix;
+    }
+
+    @Override
+    public String getProcessConfigKeyPrefix() {
+        return processConfigKeyPrefix;
     }
 
     @Override

--- a/src/test/java/com/neopragma/cobolcheck/DriverTests.java
+++ b/src/test/java/com/neopragma/cobolcheck/DriverTests.java
@@ -1,0 +1,73 @@
+package com.neopragma.cobolcheck;
+
+import com.neopragma.cobolcheck.exceptions.PossibleInternalLogicErrorException;
+import org.graalvm.compiler.core.match.MatchRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DriverTests {
+    Driver driver;
+    private static final Messages messages = new Messages();
+    private static final Config config = new Config(messages);
+
+    @BeforeAll
+    static void oneTimeSetup() {
+        config.load("testconfig.properties");
+    }
+
+    @BeforeEach
+    void commonSetup() {
+        String[] args = {"-p", "ALPHA"};
+        GetOpt options = new GetOpt(args, Constants.COMMAND_lINE_OPTIONS, config);
+        driver = new Driver(config, options);
+    }
+
+    @Test
+    void it_gets_correct_platform() {
+        Platform platform = Platform.WINDOWS;
+        ProcessLauncher launcher = driver.getPlatformSpecificLauncher(platform);
+        assertEquals("windows", launcher.getProcessConfigKeyPrefix());
+    }
+
+    @Test
+    void cobol_source_directory_exists() {
+        String path = driver.getCobolSourceDirectory();
+        File file = new File(path);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void test_source_out_path_exists() {
+        String path = driver.getTestSourceOutPath();
+        File file = new File(path);
+        assertTrue(file.exists());
+    }
+
+    @Test
+    void finds_correct_file_suffix() {
+        String[] suffixes = {".cbl", ".cob", ".txt", ".java"};
+        List<String> suffixList = Arrays.asList(suffixes);
+        String fullPath = "fake\\fake\\file.txt";
+        String pathWithNoSuffix = "fake\\fake\\file";
+        MockedStatic<Files> mockedFiles = Mockito.mockStatic(Files.class);
+        mockedFiles.when(() -> Files.isRegularFile(Paths.get(fullPath)))
+                .thenReturn(true);
+        String appended = driver.appendMatchingFileSuffix(pathWithNoSuffix, suffixList);
+
+        assertEquals(fullPath, appended);
+    }
+}

--- a/src/test/java/com/neopragma/cobolcheck/DriverTests.java
+++ b/src/test/java/com/neopragma/cobolcheck/DriverTests.java
@@ -68,6 +68,8 @@ public class DriverTests {
                 .thenReturn(true);
         String appended = driver.appendMatchingFileSuffix(pathWithNoSuffix, suffixList);
 
+        mockedFiles.close();
+
         assertEquals(fullPath, appended);
     }
 }


### PR DESCRIPTION
### General Changes:
- Changed dependency; `mockito-core` to `mockito-inline` in build.gradle in order to use in-line mocking.
- Added `DriverTests`. These tests should be moved to other test classes, as the Driver class delegates its responsibilities.
- Added `getProcessConfigKeyPrefix` to the `ProcessLauncher` interface.
- Implemented `getProcessConfigKeyPrefix` in classes that implement the interface.

### Changes in Driver:
- Simplified `runTestSuites `from 135 to 33 lines.
- Altered the method; `mergeTestSuitesIntoTheTestProgram`
- Added method; `runTestProgram`
- Added method; `endWithFileSeparator`
- Added method; `launchProgram`
- Added method; `getPlatformSpecificLauncher`
- Added method; `getCobolSourceDirectory`
- Added method; `getSourceReader`
- Added method; `getTestSuiteReader`
- Added method; `getTestSourceOutPath`
- Added method; `getTestSourceWriter`
- Added method; `appendMatchingFileSuffix`
- Added method; `getMatchingDirectories`
- Structured and commented methods based upon their use. This can be used to later delegate the responsibility of the `Driver `class, into other classes.