### PR TITLE
Count mock calls

### DIFF
--- a/src/main/java/com/neopragma/cobolcheck/exceptions/VerifyReferencesNonexistentMockException.java
+++ b/src/main/java/com/neopragma/cobolcheck/exceptions/VerifyReferencesNonexistentMockException.java
@@ -1,0 +1,7 @@
+package com.neopragma.cobolcheck.exceptions;
+
+public class VerifyReferencesNonexistentMockException extends RuntimeException {
+    public VerifyReferencesNonexistentMockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keyword.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keyword.java
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package com.neopragma.cobolcheck.services.cobolLogic;
+package com.neopragma.cobolcheck.features.testSuiteParser;
 
 import com.neopragma.cobolcheck.features.testSuiteParser.KeywordAction;
 

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/KeywordExtractor.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/KeywordExtractor.java
@@ -37,6 +37,10 @@ public class KeywordExtractor implements TokenExtractor {
         nextExpectedTokens = new ArrayList<>();
         multiWordTokens = new HashMap<>();
         multiWordTokens.put("TO", Arrays.asList("BE", "EQUAL"));
+        multiWordTokens.put("NEVER", Arrays.asList("HAPPENED"));
+        multiWordTokens.put("AT", Arrays.asList("LEAST"));
+        multiWordTokens.put("NO", Arrays.asList("MORE", "THAN"));
+
     }
 
     @Override
@@ -90,16 +94,20 @@ public class KeywordExtractor implements TokenExtractor {
                             for (String expectedToken : nextExpectedTokens) {
                                 int endOfLookahead = startOfLookahead + expectedToken.length();
                                 if (sourceLine.length() >= endOfLookahead) {
-                                    if (expectedToken.equalsIgnoreCase(sourceLine.substring(startOfLookahead, endOfLookahead))
+                                    String temp = sourceLine.substring(startOfLookahead, endOfLookahead);
+                                    if (expectedToken.equalsIgnoreCase(temp)
                                             && (endOfLookahead == sourceLine.length()
                                             || sourceLine.charAt(endOfLookahead) == SPACE)) {
                                         buffer.append(expectedToken);
                                         tokenOffset += expectedToken.length();
-                                        break;
+                                        buffer.append(SPACE);
+                                        startOfLookahead = tokenOffset + 2;
+//                                        break;
                                     }
                                 }
 
                             }
+                            buffer.deleteCharAt(buffer.length() - 1);
                             buffer = addTokenAndClearBuffer(buffer, tokens);
                             nextExpectedTokens = new ArrayList<>();
                         } else {

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keywords.java
@@ -13,15 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package com.neopragma.cobolcheck.services.cobolLogic;
+package com.neopragma.cobolcheck.features.testSuiteParser;
 
-import com.neopragma.cobolcheck.features.testSuiteParser.KeywordAction;
 import com.neopragma.cobolcheck.services.Constants;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This is a container for Keyword records. It is used when parsing test suites to identify cobol-check
@@ -134,7 +130,8 @@ public class Keywords {
                         KeywordAction.FIELDNAME));
         keywordInfo.put(Constants.NUMERIC_LITERAL_KEYWORD,
                 new Keyword(Constants.NUMERIC_LITERAL_KEYWORD,
-                        Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN),
+                        Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN, Constants.TIME_KEYWORD,
+                                Constants.TIMES_KEYWORD),
                         KeywordAction.FIELDNAME));
         keywordInfo.put(Constants.COBOL_TOKEN,
                 new Keyword(Constants.COBOL_TOKEN,
@@ -154,6 +151,39 @@ public class Keywords {
         keywordInfo.put(Constants.MOCK_TYPE,
                 new Keyword(Constants.MOCK_TYPE,
                         Arrays.asList(Constants.COBOL_TOKEN),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.VERIFY_KEYWORD,
+                new Keyword(Constants.VERIFY_KEYWORD,
+                        Arrays.asList(Constants.MOCK_TYPE),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.NEVER_HAPPENED_KEYWORD,
+                new Keyword(Constants.NEVER_HAPPENED_KEYWORD,
+                        Collections.emptyList(),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.HAPPENED_KEYWORD,
+                new Keyword(Constants.HAPPENED_KEYWORD,
+                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.AT_LEAST_KEYWORD,
+                                Constants.NO_MORE_THAN_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.ONCE_KEYWORD,
+                new Keyword(Constants.ONCE_KEYWORD,
+                        Collections.emptyList(),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.AT_LEAST_KEYWORD,
+                new Keyword(Constants.AT_LEAST_KEYWORD,
+                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.NO_MORE_THAN_KEYWORD,
+                new Keyword(Constants.NO_MORE_THAN_KEYWORD,
+                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.TIME_KEYWORD,
+                new Keyword(Constants.TIME_KEYWORD,
+                        Collections.emptyList(),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.TIMES_KEYWORD,
+                new Keyword(Constants.TIMES_KEYWORD,
+                        Collections.emptyList(),
                         KeywordAction.NONE));
 
         //TODO: Add other types that can be mocked

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -31,6 +31,14 @@ public class Mock {
         return "UT-" + getGeneratedMockIdentifier() + "-COUNT";
     }
 
+    public String getGeneratedMockCountExpectedIdentifier(){
+        return "UT-" + getGeneratedMockIdentifier() + "-EXPECTED";
+    }
+
+    public String getGeneratedMockStringIdentifierName(){
+        return "UT-" + getGeneratedMockIdentifier() + "-NAME";
+    }
+
     public List<String> getCommentText(){
         List<String> lines = new ArrayList<>();
         lines.add("      *****************************************************************");

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -27,6 +27,10 @@ public class Mock {
         return testSuiteNumber + "-" + testCaseNumber + "-" + mockNumber + "-MOCK";
     }
 
+    public String getGeneratedMockCountIdentifier(){
+        return "UT-" + getGeneratedMockIdentifier() + "-COUNT";
+    }
+
     public List<String> getCommentText(){
         List<String> lines = new ArrayList<>();
         lines.add("      *****************************************************************");

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -27,9 +27,17 @@ public class Mock {
         return testSuiteNumber + "-" + testCaseNumber + "-" + mockNumber + "-MOCK";
     }
 
-    public String getCommentText(){
-        return scope.name() + "mock created from test case: " + testCaseName + " in test suite: " + testSuiteName +
-                "for the " + type + ": " + identifier;
+    public List<String> getCommentText(){
+        List<String> lines = new ArrayList<>();
+        lines.add("      *****************************************************************");
+        lines.add(scope.name() + " mock of: " + type + ": " + identifier);
+        lines.add("In testsuite: " + testSuiteName);
+        if (scope == MockScope.Local){
+            lines.add("In testcase: " + testCaseName);
+        }
+        lines.add("      *****************************************************************");
+        return lines;
+
     }
 
     public String getIdentifier() {

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -39,6 +39,10 @@ public class Mock {
         return "UT-" + getGeneratedMockIdentifier() + "-NAME";
     }
 
+    public String getMockDisplayString(){
+        return type.toUpperCase() + " " + identifier;
+    }
+
     public List<String> getCommentText(){
         List<String> lines = new ArrayList<>();
         lines.add("      *****************************************************************");

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -3,6 +3,7 @@ package com.neopragma.cobolcheck.features.testSuiteParser;
 import com.neopragma.cobolcheck.services.StringHelper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class MockGenerator {
@@ -13,6 +14,30 @@ public class MockGenerator {
     private final String whenOtherLine = "           WHEN OTHER";
     private final String endEvaluateLine = "            END-EVALUATE";
     private final String anyKeyword = "ANY";
+
+
+    List<String> generateWorkingStorageMockCountLines(List<Mock> mocks){
+        List<String> lines = new ArrayList<>();
+        lines.add("       01  UT-MOCKS-GENERATED.");
+        lines.addAll(generateMockCounters(mocks));
+
+        return lines;
+    }
+
+    List<String> generateMockCountInitializer(List<Mock> mocks){
+        List<String> lines = new ArrayList<>();
+        lines.add("       UT-INITIALIZE-MOCK-COUNT SECTION.");
+        lines.add("      *****************************************************************");
+        lines.add(StringHelper.commentOutLine("       Sets all global mock counters to 0"));
+        lines.add("      *****************************************************************");
+        for (Mock mock : mocks){
+            if (mock.getScope() == MockScope.Global){
+                lines.add("           MOVE 0 TO " + mock.getGeneratedMockCountIdentifier());
+            }
+        }
+        lines.add("       .");
+        return lines;
+    }
 
     /**Generates the lines for SECTIONs based on mocks,
      * for each mock in a given list.
@@ -66,6 +91,14 @@ public class MockGenerator {
         return endEvaluateLine;
     }
 
+    private List<String> generateMockCounters(List<Mock> mocks) {
+        List<String> lines = new ArrayList<>();
+        for (Mock mock : mocks){
+            lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO.");
+        }
+        return lines;
+    }
+
     private List<String> getMockSectionCommentHeader(){
         List<String> lines = new ArrayList<>();
         lines.add("      *****************************************************************");
@@ -82,6 +115,7 @@ public class MockGenerator {
                 lines.add(StringHelper.commentOutLine(line));
             }
         }
+        lines.add("           ADD 1 TO " + mock.getGeneratedMockCountIdentifier());
         lines.addAll(mock.getLines());
         lines.add("       .");
         return lines;

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -19,11 +19,11 @@ public class MockGenerator {
      * @param mocks - The mocks to generate SECTIONs for
      * @return The generated lines
      */
-    List<String> generateMockSections(List<Mock> mocks){
+    List<String> generateMockSections(List<Mock> mocks, boolean withComments){
 
         List<String> lines = new ArrayList<>(getMockSectionCommentHeader());
         for (Mock mock : mocks){
-            lines.addAll(generateSectionForMock(mock));
+            lines.addAll(generateSectionForMock(mock, withComments));
             lines.add("");
         }
         return lines;
@@ -74,10 +74,14 @@ public class MockGenerator {
         return lines;
     }
 
-    private List<String> generateSectionForMock(Mock mock){
+    private List<String> generateSectionForMock(Mock mock, boolean withComment){
         List<String> lines = new ArrayList<>();
-//        lines.add(StringHelper.commentOutLine("       " + mock.getCommentText()));
         lines.add("       " + mock.getGeneratedMockIdentifier() + " SECTION.");
+        if (withComment){
+            for (String line : mock.getCommentText()){
+                lines.add(StringHelper.commentOutLine(line));
+            }
+        }
         lines.addAll(mock.getLines());
         lines.add("       .");
         return lines;

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -15,6 +15,14 @@ public class MockGenerator {
     private final String anyKeyword = "ANY";
 
 
+    /**Generates the lines for keeping track of mock counting
+     * For each mock a variable are created for:
+     * - Current count
+     * - Expected count
+     * - Mock operation (string showing type and identity)
+     * @param mocks - The mocks to generate lines for
+     * @return The generated lines
+     */
     List<String> generateWorkingStorageMockCountLines(List<Mock> mocks){
         List<String> lines = new ArrayList<>();
         lines.add("       01  UT-MOCKS-GENERATED.");
@@ -23,6 +31,11 @@ public class MockGenerator {
         return lines;
     }
 
+    /**Generates the lines for the initializer section.
+     * This resets the current count and expected count of all global mocks in cobol.
+     * @param mocks - The mocks to generate lines for
+     * @return The generated lines
+     */
     List<String> generateMockCountInitializer(List<Mock> mocks){
         List<String> lines = new ArrayList<>();
         lines.add("       UT-INITIALIZE-MOCK-COUNT SECTION.");
@@ -96,7 +109,8 @@ public class MockGenerator {
         for (Mock mock : mocks){
             lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO.");
             lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(02) VALUE ZERO.");
-            lines.add("           05  " + mock.getGeneratedMockStringIdentifierName() + "        PIC X(20) VALUE \"" + mock.getIdentifier() + "\".");
+            lines.add("           05  " + mock.getGeneratedMockStringIdentifierName() + "        PIC X(20)");
+            lines.add("                   VALUE \"" + mock.getMockDisplayString() + "\".");
         }
         return lines;
     }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -3,7 +3,6 @@ package com.neopragma.cobolcheck.features.testSuiteParser;
 import com.neopragma.cobolcheck.services.StringHelper;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class MockGenerator {
@@ -19,7 +18,7 @@ public class MockGenerator {
     List<String> generateWorkingStorageMockCountLines(List<Mock> mocks){
         List<String> lines = new ArrayList<>();
         lines.add("       01  UT-MOCKS-GENERATED.");
-        lines.addAll(generateMockCounters(mocks));
+        lines.addAll(generateMockCountValues(mocks));
 
         return lines;
     }
@@ -28,11 +27,12 @@ public class MockGenerator {
         List<String> lines = new ArrayList<>();
         lines.add("       UT-INITIALIZE-MOCK-COUNT SECTION.");
         lines.add("      *****************************************************************");
-        lines.add(StringHelper.commentOutLine("       Sets all global mock counters to 0"));
+        lines.add(StringHelper.commentOutLine("       Sets all global mock counters and expected count to 0"));
         lines.add("      *****************************************************************");
         for (Mock mock : mocks){
             if (mock.getScope() == MockScope.Global){
                 lines.add("           MOVE 0 TO " + mock.getGeneratedMockCountIdentifier());
+                lines.add("           MOVE 0 TO " + mock.getGeneratedMockCountExpectedIdentifier());
             }
         }
         lines.add("       .");
@@ -91,10 +91,12 @@ public class MockGenerator {
         return endEvaluateLine;
     }
 
-    private List<String> generateMockCounters(List<Mock> mocks) {
+    private List<String> generateMockCountValues(List<Mock> mocks) {
         List<String> lines = new ArrayList<>();
         for (Mock mock : mocks){
             lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO.");
+            lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(02) VALUE ZERO.");
+            lines.add("           05  " + mock.getGeneratedMockStringIdentifierName() + "        PIC X(20) VALUE \"" + mock.getIdentifier() + "\".");
         }
         return lines;
     }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
@@ -25,6 +25,7 @@ public class MockRepository {
     }
 
     public Mock getMockFor(String identifier, String testSuite, String testCase){
+        List<Mock> globalMocks = new ArrayList<>();
         for (Mock mock: mocks) {
             if (mock.getIdentifier().equals(identifier)){
                 if (mock.getScope() == MockScope.Local){
@@ -33,12 +34,18 @@ public class MockRepository {
                     }
                 }
                 if (mock.getScope() == MockScope.Global){
-                    if (mock.getTestSuiteName().equals(testSuite)){
-                        return mock;
-                    }
+                    //We need to check all local mocks first, and save global mocks for later
+                    globalMocks.add(mock);
                 }
             }
         }
+        for (Mock mock: globalMocks) {
+            if (mock.getTestSuiteName().equals(testSuite)){
+                return mock;
+            }
+        }
+
+
         return null;
     }
 

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
@@ -11,6 +11,10 @@ public class MockRepository {
         mocks.add(mock);
     }
 
+    public List<Mock> getMocks(){
+        return mocks;
+    }
+
     public boolean mockExistsFor(String identifier){
         for (Mock mock: mocks) {
             if (mock.getIdentifier().equals(identifier)){
@@ -20,7 +24,23 @@ public class MockRepository {
         return false;
     }
 
-    public List<Mock> getMocks(){
-        return mocks;
+    public Mock getMockFor(String identifier, String testSuite, String testCase){
+        for (Mock mock: mocks) {
+            if (mock.getIdentifier().equals(identifier)){
+                if (mock.getScope() == MockScope.Local){
+                    if (mock.getTestSuiteName().equals(testSuite) && mock.getTestCaseName().equals(testCase)){
+                        return mock;
+                    }
+                }
+                if (mock.getScope() == MockScope.Global){
+                    if (mock.getTestSuiteName().equals(testSuite)){
+                        return mock;
+                    }
+                }
+            }
+        }
+        return null;
     }
+
+
 }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -94,6 +94,8 @@ public class TestSuiteParser {
             "               TO %sTEST-SUITE-NAME";
     private static final String COBOL_PERFORM_BEFORE =
             "           PERFORM %sBEFORE";
+    private static final String COBOL_PERFORM_INITIALIZE_MOCK_COUNT =
+            "           PERFORM %sINITIALIZE-MOCK-COUNT";
     private static final String COBOL_INCREMENT_TEST_CASE_COUNT =
             "           ADD 1 TO %sTEST-CASE-COUNT";
 
@@ -484,6 +486,7 @@ public class TestSuiteParser {
         parsedTestSuiteLines.add(String.format(COBOL_STORE_TESTCASE_NAME_1, testCaseName));
         parsedTestSuiteLines.add(String.format(COBOL_STORE_TESTCASE_NAME_2, testCodePrefix));
         parsedTestSuiteLines.add(String.format(COBOL_PERFORM_BEFORE, testCodePrefix));
+        parsedTestSuiteLines.add(String.format(COBOL_PERFORM_INITIALIZE_MOCK_COUNT, testCodePrefix));
     }
 
     public void addPerformBeforeEachLine(List<String> parsedTestSuiteLines) {

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
@@ -120,7 +120,7 @@ public class TestSuiteParserController {
         // Inject boilerplate test code from cobol-check Procedure Division copybook
         lines.addAll(getBoilerplateCodeFromCopybooks(procedureDivisionCopybookFilename));
 
-        lines.addAll(generateMockSections());
+        lines.addAll(generateMockSections(true));
         return lines;
     }
 
@@ -128,8 +128,8 @@ public class TestSuiteParserController {
      * for each mock in a given list.
      * @return The generated lines
      */
-    public List<String> generateMockSections(){
-        return mockGenerator.generateMockSections(mockRepository.getMocks());
+    public List<String> generateMockSections(boolean withComments){
+        return mockGenerator.generateMockSections(mockRepository.getMocks(), withComments);
     }
 
     public boolean mockExistsFor(String identifier){

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/VerifyMockCount.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/VerifyMockCount.java
@@ -1,0 +1,55 @@
+package com.neopragma.cobolcheck.features.testSuiteParser;
+
+public class VerifyMockCount{
+    private Mock attachedMock;
+    private String expectedCount;
+    private boolean atLeast;
+    private boolean noMoreThan;
+    private String identifier;
+
+    public String getExpectedCount() {
+        return expectedCount;
+    }
+
+    public boolean isSetToAtLeast() {
+        return atLeast;
+    }
+
+    public boolean isSetToNoMoreThan() {
+        return noMoreThan;
+    }
+
+    public Mock getAttachedMock() {
+        return attachedMock;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public void setAttachedMock(Mock attachedMock) {
+        this.attachedMock = attachedMock;
+    }
+
+    void expectExact(String expectedCount){
+        this.expectedCount = expectedCount;
+        atLeast = false;
+        noMoreThan = false;
+    }
+
+    void expectAtLeast(String expectedCount){
+        this.expectedCount = expectedCount;
+        atLeast = true;
+        noMoreThan = false;
+    }
+
+    void expectNoMoreThan(String expectedCount){
+        this.expectedCount = expectedCount;
+        atLeast = false;
+        noMoreThan = true;
+    }
+}

--- a/src/main/java/com/neopragma/cobolcheck/services/Constants.java
+++ b/src/main/java/com/neopragma/cobolcheck/services/Constants.java
@@ -78,6 +78,14 @@ public final class Constants {
     public static final String MOCK_KEYWORD = "MOCK";
     public static final String MOCK_TYPE = "mock-type";
     public static final String ENDMOCK_KEYWORD = "END-MOCK";
+    public static final String VERIFY_KEYWORD = "VERIFY";
+    public static final String NEVER_HAPPENED_KEYWORD = "NEVER HAPPENED";
+    public static final String HAPPENED_KEYWORD = "HAPPENED";
+    public static final String ONCE_KEYWORD = "ONCE";
+    public static final String AT_LEAST_KEYWORD = "AT LEAST";
+    public static final String NO_MORE_THAN_KEYWORD = "NO MORE THAN";
+    public static final String TIME_KEYWORD = "TIME";
+    public static final String TIMES_KEYWORD = "TIMES";
 
     // Configuration key values
     public static final String CONCATENATED_TEST_SUITES_CONFIG_KEY = "concatenated.test.suites";

--- a/src/main/java/com/neopragma/cobolcheck/services/StringHelper.java
+++ b/src/main/java/com/neopragma/cobolcheck/services/StringHelper.java
@@ -110,7 +110,16 @@ public class StringHelper {
 
 
     public static String commentOutLine(String line){
-        return "      *" + line.substring(Constants.COMMENT_SPACE_OFFSET);
+        if (line.startsWith("       ")){
+            return "      *" + line.substring(Constants.COMMENT_SPACE_OFFSET);
+        }
+        if (line.startsWith("      *")){
+            return line;
+        }
+        else {
+            return "      *" + line;
+        }
+
     }
 
     /**

--- a/src/main/java/com/neopragma/cobolcheck/workers/Generator.java
+++ b/src/main/java/com/neopragma/cobolcheck/workers/Generator.java
@@ -165,13 +165,13 @@ public class Generator {
     private void processingAfterEchoingSourceLineToOutput() throws IOException {
 
         if (interpreter.currentLineContains(Constants.WORKING_STORAGE_SECTION)) {
+            testSuiteParserController.parseTestSuites(interpreter.getNumericFields());
             writerController.writeLines(testSuiteParserController.getWorkingStorageTestCode(
                     interpreter.getFileSectionStatements()));
         }
 
         if (interpreter.currentLineContains(Constants.PROCEDURE_DIVISION)) {
-            writerController.writeLines(testSuiteParserController.getProcedureDivisionTestCode(
-                    interpreter.getNumericFields()));
+            writerController.writeLines(testSuiteParserController.getProcedureDivisionTestCode());
         }
 
         if (interpreter.isCurrentComponentMockable()){

--- a/src/main/resources/com/neopragma/cobolcheck/copybooks/CCHECKPD.CPY
+++ b/src/main/resources/com/neopragma/cobolcheck/copybooks/CCHECKPD.CPY
@@ -164,183 +164,63 @@
            SET ==UT==VERIFY-FAILED TO TRUE
            EVALUATE TRUE
                WHEN ==UT==VERIFY-AT-LEAST
-                    IF ==UT==ACTUAL-ACCESSES IS GREATER THAN OR EQUAL TO 
+                    IF ==UT==ACTUAL-ACCESSES IS GREATER THAN OR EQUAL TO
                             ==UT==EXPECTED-ACCESSES
                         SET ==UT==VERIFY-PASSED TO TRUE
-                    END-IF    
+                        MOVE ==UT==VERIFY-AT-LEAST-STRING TO
+                            ==UT==LABEL-VERIFY-COMPARE
+                    END-IF
                WHEN ==UT==VERIFY-NO-MORE-THAN
                     IF ==UT==ACTUAL-ACCESSES IS LESS THAN OR EQUAL TO
                             ==UT==EXPECTED-ACCESSES
                         SET ==UT==VERIFY-PASSED TO TRUE
-                    END-IF        
+                        MOVE ==UT==VERIFY-NO-MORE-THAN-STRING TO
+                            ==UT==LABEL-VERIFY-COMPARE
+                    END-IF
                WHEN OTHER
                     IF ==UT==ACTUAL-ACCESSES IS EQUAL TO
                             ==UT==EXPECTED-ACCESSES
                         SET ==UT==VERIFY-PASSED TO TRUE
-                    END-IF        
-           END-EVALUATE    
+                        MOVE ==UT==VERIFY-EXACT-STRING TO
+                            ==UT==LABEL-VERIFY-COMPARE
+                    END-IF
+           END-EVALUATE
 
            IF ==UT==VERIFY-PASSED
                ADD 1 TO ==UT==NUMBER-PASSED
-               DISPLAY ==UT==PASSED 
-                       ==UT==TEST-CASE-NUMBER '. ' 
-                      'VERIFY ' ==UT==EXPECTED-ACCESSES-FMT SPACE
-                      ==UT==LABEL-EXPECTED-ACCESS
+               DISPLAY ==UT==PASSED
+                       ==UT==TEST-CASE-NUMBER '. '
+                      'VERIFY ' ==UT==LABEL-VERIFY-COMPARE
+                      ==UT==EXPECTED-ACCESSES-FMT SPACE
+                      ==UT==LABEL-EXPECTED-ACCESS ' '
+                      'TO ' ==UT==MOCK-OPERATION
+
            ELSE 
                ADD 1 TO ==UT==NUMBER-FAILED
                MOVE SPACES TO ==UT==DISPLAY-MESSAGE
-               IF ==UT==MOCK-FILE(==UT==MOCK-IX)
-                   STRING 
-                       ==UT==FAILED                      DELIMITED BY SIZE
-                       ==UT==TEST-CASE-NUMBER            DELIMITED BY SIZE
-                       '. VERIFY ACCESSES TO '        DELIMITED BY SIZE
-                       ==UT==MOCK-OPERATION(==UT==MOCK-IX)  DELIMITED BY SPACE
-                       ' ON '                         DELIMITED BY SIZE
-                       ==UT==MOCK-FILENAME(==UT==MOCK-IX)   DELIMITED BY SPACE
-                       ' | EXPECTED '                 DELIMITED BY SIZE
-                       ==UT==EXPECTED-ACCESSES-FMT       DELIMITED BY SIZE
-                       SPACE                          DELIMITED BY SIZE
-                       ==UT==LABEL-EXPECTED-ACCESS       DELIMITED BY SPACE
-                       ', WAS '                       DELIMITED BY SIZE
-                       ==UT==ACTUAL-ACCESSES-FMT         DELIMITED BY SIZE
-                       INTO ==UT==DISPLAY-MESSAGE
-                   END-STRING
-               ELSE
-                   STRING 
-                       ==UT==FAILED                      DELIMITED BY SIZE
-                       ==UT==TEST-CASE-NUMBER            DELIMITED BY SIZE
-                       '. VERIFY ACCESSES TO '        DELIMITED BY SIZE
-                       ==UT==MOCK-CICS-KEYWORDS-KEY(==UT==MOCK-IX)
-                                                      DELIMITED BY SIZE
-                       INTO ==UT==DISPLAY-MESSAGE
-                   END-STRING     
-                   DISPLAY ==UT==DISPLAY-MESSAGE
-                   MOVE SPACES TO ==UT==DISPLAY-MESSAGE
-                   STRING 
-                       '   EXPECTED '                 DELIMITED BY SIZE
-                       ==UT==EXPECTED-ACCESSES-FMT       DELIMITED BY SIZE
-                       SPACE                          DELIMITED BY SIZE
-                       ==UT==LABEL-EXPECTED-ACCESS       DELIMITED BY SPACE
-                       ', WAS '                       DELIMITED BY SIZE
-                       ==UT==ACTUAL-ACCESSES-FMT         DELIMITED BY SIZE
-                       INTO ==UT==DISPLAY-MESSAGE
-                   END-STRING                                  
-               END-IF    
+               STRING
+                   ==UT==FAILED                      DELIMITED BY SIZE
+                   ==UT==TEST-CASE-NUMBER            DELIMITED BY SIZE
+                   '. VERIFY ACCESSES TO '        DELIMITED BY SIZE
+                   ==UT==MOCK-OPERATION           DELIMITED BY SIZE
+                   INTO ==UT==DISPLAY-MESSAGE
+               END-STRING
+               DISPLAY ==UT==DISPLAY-MESSAGE
+               MOVE SPACES TO ==UT==DISPLAY-MESSAGE
+               STRING
+                   '   EXPECTED '                 DELIMITED BY SIZE
+                   ==UT==LABEL-VERIFY-COMPARE ' ' DELIMITED BY SIZE
+                   ==UT==EXPECTED-ACCESSES-FMT       DELIMITED BY SIZE
+                   SPACE                          DELIMITED BY SIZE
+                   ==UT==LABEL-EXPECTED-ACCESS       DELIMITED BY SPACE
+                   ', WAS '                       DELIMITED BY SIZE
+                   ==UT==ACTUAL-ACCESSES-FMT         DELIMITED BY SIZE
+                   INTO ==UT==DISPLAY-MESSAGE
+               END-STRING
                DISPLAY ==UT==DISPLAY-MESSAGE
                MOVE 4 TO ==UT==RETCODE
            END-IF              
-           . 
-
-       ==UT==SET-MOCK.
-      *****************************************************************
-      * CREATE OR UPDATE A MOCK SPECIFICATION.
-      *****************************************************************
-           EVALUATE TRUE
-               WHEN ==UT==FIND-FILE-MOCK
-                    PERFORM ==UT==SET-FILE-MOCK
-               WHEN ==UT==FIND-CALL-MOCK
-                    PERFORM ==UT==SET-CALL-MOCK
-               WHEN ==UT==FIND-CICS-MOCK
-                    PERFORM ==UT==SET-CICS-MOCK
-               WHEN ==UT==FIND-PARA-MOCK
-                    PERFORM ==UT==SET-PARA-MOCK          
-           END-EVALUATE
            .
-
-       ==UT==SET-FILE-MOCK.
-           PERFORM ==UT==LOOKUP-MOCK
-           IF ==UT==MOCK-FOUND
-               CONTINUE
-           ELSE    
-               ADD 1 TO ==UT==MOCK-COUNT
-               SET ==UT==MOCK-IX TO ==UT==MOCK-COUNT
-               SET ==UT==MOCK-FILE(==UT==MOCK-IX) TO TRUE
-               MOVE ==UT==MOCK-FIND-FILENAME 
-                    TO ==UT==MOCK-FILENAME(==UT==MOCK-IX)
-               MOVE ==UT==MOCK-FIND-OPERATION
-                    TO ==UT==MOCK-OPERATION(==UT==MOCK-IX)
-           END-IF
-           MOVE ==UT==MOCK-SET-RECORD 
-                TO ==UT==MOCK-RECORD(==UT==MOCK-IX)
-           MOVE ==UT==MOCK-SET-FILE-STATUS 
-                TO ==UT==MOCK-FILE-STATUS(==UT==MOCK-IX)
-           .    
-
-       ==UT==SET-CALL-MOCK.
-           PERFORM ==UT==LOOKUP-MOCK
-           IF ==UT==MOCK-FOUND
-               CONTINUE
-           ELSE    
-               ADD 1 TO ==UT==MOCK-COUNT
-               SET ==UT==MOCK-IX TO ==UT==MOCK-COUNT
-               MOVE ==UT==MOCK-FIND-CALL-TOKENS
-                   TO ==UT==MOCK-CALL-TOKENS-KEY(==UT==MOCK-IX)
-           END-IF
-           .    
-
-       ==UT==SET-CICS-MOCK.
-           PERFORM ==UT==LOOKUP-MOCK
-           IF ==UT==MOCK-FOUND
-               CONTINUE
-           ELSE    
-               ADD 1 TO ==UT==MOCK-COUNT
-               SET ==UT==MOCK-IX TO ==UT==MOCK-COUNT
-               MOVE ==UT==MOCK-FIND-CICS-KEYWORDS
-                   TO ==UT==MOCK-CICS-KEYWORDS-KEY(==UT==MOCK-IX)
-           END-IF
-           .    
-
-       ==UT==SET-PARA-MOCK.
-           PERFORM ==UT==LOOKUP-MOCK
-           IF ==UT==MOCK-FOUND
-               CONTINUE
-           ELSE
-               ADD 1 TO ==UT==MOCK-COUNT
-               SET ==UT==MOCK-IX TO ==UT==MOCK-COUNT
-               MOVE ==UT==MOCK-FIND-PARA-NAME
-                   TO ==UT==MOCK-PARA-NAME(==UT==MOCK-IX)
-           END-IF            
-           .
-
-       ==UT==LOOKUP-MOCK.
-      *****************************************************************
-      * LOOK UP A MOCK SPECIFICATION.
-      *****************************************************************
-           SET ==UT==MOCK-NOT-FOUND TO TRUE
-           PERFORM VARYING ==UT==MOCK-IX FROM 1 BY 1
-               UNTIL ==UT==MOCK-IX IS GREATER THAN ==UT==MOCK-MAX
-                  OR ==UT==MOCK-FOUND
-               EVALUATE TRUE
-                   WHEN ==UT==FIND-FILE-MOCK   
-                       IF ==UT==MOCK-FIND-FILENAME IS EQUAL TO
-                              ==UT==MOCK-FILENAME(==UT==MOCK-IX)
-                       AND ==UT==MOCK-FIND-OPERATION IS EQUAL TO
-                              ==UT==MOCK-OPERATION(==UT==MOCK-IX)
-                           SET ==UT==MOCK-FOUND TO TRUE
-                           CONTINUE
-                       END-IF
-                   WHEN ==UT==FIND-CALL-MOCK
-                       IF ==UT==MOCK-FIND-CALL-TOKENS IS EQUAL TO
-                              ==UT==MOCK-CALL-TOKENS-KEY(==UT==MOCK-IX)
-                           SET ==UT==MOCK-FOUND TO TRUE
-                           CONTINUE
-                       END-IF         
-                   WHEN ==UT==FIND-CICS-MOCK
-                       IF ==UT==MOCK-FIND-CICS-KEYWORDS IS EQUAL TO
-                              ==UT==MOCK-CICS-KEYWORDS-KEY(==UT==MOCK-IX)
-                           SET ==UT==MOCK-FOUND TO TRUE
-                           CONTINUE
-                       END-IF         
-                   WHEN ==UT==FIND-PARA-MOCK
-                       IF ==UT==MOCK-FIND-PARA-NAME IS EQUAL TO
-                              ==UT==MOCK-PARA-NAME(==UT==MOCK-IX)
-                           SET ==UT==MOCK-FOUND TO TRUE
-                           CONTINUE
-                       END-IF               
-               END-EVALUATE
-           END-PERFORM    
-           SET ==UT==MOCK-IX DOWN BY 1
-           .    
 
        ==UT==LOOKUP-FILE.
       *****************************************************************

--- a/src/main/resources/com/neopragma/cobolcheck/copybooks/CCHECKWS.CPY
+++ b/src/main/resources/com/neopragma/cobolcheck/copybooks/CCHECKWS.CPY
@@ -6,6 +6,15 @@
                10  FILLER                PIC X(06) VALUE 'ACCESS'.
                10  ==UT==LABEL-EXPECTED-ACCESS-PL 
                                          PIC X(02) VALUE SPACES.
+           05  ==UT==LABEL-VERIFY-COMPARE
+                                         PIC X(12) VALUE SPACES.
+           05  ==UT==VERIFY-COMPARE-STRINGS.
+               10  ==UT==VERIFY-EXACT-STRING
+                                         PIC X(05) VALUE 'EXACT'.
+               10  ==UT==VERIFY-AT-LEAST-STRING
+                                         PIC X(08) VALUE 'AT LEAST'.
+               10  ==UT==VERIFY-NO-MORE-THAN-STRING
+                                         PIC X(12) VALUE 'NO MORE THAN'.
            05  ==UT==DISPLAY-MESSAGE     PIC X(256) VALUE SPACES.
            05  FILLER                    PIC X(02) VALUE SPACES.
                88  ==UT==RELATION-EQ               VALUE SPACES, 'EQ'.
@@ -78,6 +87,7 @@
            05  ==UT==MOCK-SET-FILE-STATUS   PIC X(02).
            05  ==UT==MOCK-MAX               PIC 9(02) VALUE 10.
            05  ==UT==MOCK-COUNT             PIC 9(02) VALUE ZERO.
+           05  ==UT==MOCK-OPERATION         PIC X(30).
            05  ==UT==MOCK OCCURS 20 INDEXED BY ==UT==MOCK-IX.
                10  ==UT==MOCK-TYPE          PIC X(04).
                    88  ==UT==MOCK-FILE          VALUE 'FILE'.
@@ -89,8 +99,7 @@
                10  ==UT==MOCK-RECORD        PIC X(8192).    
                10  ==UT==MOCK-DATA          PIC X(806).
                10  ==UT==MOCK-FILE-DATA REDEFINES ==UT==MOCK-DATA.        
-                   15  ==UT==MOCK-FILENAME       PIC X(31).    
-                   15  ==UT==MOCK-OPERATION      PIC X(20).  
+                   15  ==UT==MOCK-FILENAME       PIC X(31).
                    15  ==UT==MOCK-FILE-STATUS    PIC X(02).
                    15  FILLER                 PIC X(753).
                10  ==UT==MOCK-CALL-DATA REDEFINES ==UT==MOCK-DATA.

--- a/src/test/cobol/MOCKTEST/MockTest
+++ b/src/test/cobol/MOCKTEST/MockTest
@@ -9,6 +9,7 @@
            PERFORM 000-START
            Expect VALUE-1 to be "Hi"
            Expect VALUE-2 to be "Hello"
+           VERIFY SECTION 000-START HAPPENED ONCE
 
            TestCase "Local mock overwrites global mock"
            MOCK SECTION 000-START
@@ -16,21 +17,30 @@
                 MOVE "a mock" TO VALUE-2
            END-MOCK
            PERFORM 000-START
+           PERFORM 000-START
            Expect VALUE-1 to be "This is"
            Expect VALUE-2 to be "a mock"
+           VERIFY SECTION 000-START HAPPENED AT LEAST 2 TIMES
 
            TestCase "Multiple local mocks behaves as intended"
            MOCK SECTION 000-START
                 MOVE "This is" TO VALUE-1
                 MOVE "a mock" TO VALUE-2
                 PERFORM 100-WELCOME
+                PERFORM 100-WELCOME
+                PERFORM 100-WELCOME
            END-MOCK
            MOCK SECTION 100-WELCOME
                 MOVE "I'll leave VALUE-2 alone" TO VALUE-1
            END-MOCK
+           MOCK SECTION 500-SWITCH
+           END-MOCK
+           PERFORM 000-START
            PERFORM 000-START
            Expect VALUE-1 to be "I'll leave VALUE-2 alone"
            Expect VALUE-2 to be "a mock"
+           VERIFY SECTION 100-WELCOME HAPPENED NO MORE THAN 10 TIMES
+           VERIFY SECTION 500-SWITCH NEVER HAPPENED
 
            TestCase "Empty local mock makes section do nothing"
            MOCK SECTION 500-SWITCH

--- a/src/test/cobol/MOCKTEST/MockTest
+++ b/src/test/cobol/MOCKTEST/MockTest
@@ -39,6 +39,7 @@
            PERFORM 000-START
            Expect VALUE-1 to be "I'll leave VALUE-2 alone"
            Expect VALUE-2 to be "a mock"
+           VERIFY SECTION 000-START HAPPENED 5 TIMES
            VERIFY SECTION 100-WELCOME HAPPENED NO MORE THAN 10 TIMES
            VERIFY SECTION 500-SWITCH NEVER HAPPENED
 

--- a/src/test/java/com/neopragma/cobolcheck/KeywordsTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/KeywordsTest.java
@@ -108,7 +108,8 @@ public class KeywordsTest {
         Keyword keyword = Keywords.getKeywordFor("5473.19");
         assertEquals(Constants.NUMERIC_LITERAL_KEYWORD, keyword.value());
         assertEquals(KeywordAction.FIELDNAME, keyword.keywordAction());
-        assertEquals(Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN), keyword.validNextKey());
+        assertEquals(Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN, Constants.TIME_KEYWORD,
+                Constants.TIMES_KEYWORD), keyword.validNextKey());
     }
 
     @Test

--- a/src/test/java/com/neopragma/cobolcheck/KeywordsTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/KeywordsTest.java
@@ -1,9 +1,9 @@
 package com.neopragma.cobolcheck;
 
 import com.neopragma.cobolcheck.features.testSuiteParser.KeywordAction;
-import com.neopragma.cobolcheck.services.cobolLogic.Keywords;
+import com.neopragma.cobolcheck.features.testSuiteParser.Keywords;
 import com.neopragma.cobolcheck.services.Constants;
-import com.neopragma.cobolcheck.services.cobolLogic.Keyword;
+import com.neopragma.cobolcheck.features.testSuiteParser.Keyword;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/src/test/java/com/neopragma/cobolcheck/MockingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockingTest.java
@@ -194,6 +194,7 @@ public class MockingTest {
         expected.add("      *Sections called when mocking");
         expected.add("      *****************************************************************");
         expected.add("       1-1-1-MOCK SECTION.");
+        expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
         expected.add(str4);
         expected.add(str5);
         expected.add("       .");
@@ -201,7 +202,8 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual = testSuiteParserController.generateMockSections(false);
 
@@ -227,6 +229,7 @@ public class MockingTest {
         expected.add("      *In testsuite: \"Name of test suite\"");
         expected.add("      *In testcase: \"Name of test case\"");
         expected.add("      *****************************************************************");
+        expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
         expected.add(str4);
         expected.add(str5);
         expected.add("       .");
@@ -234,7 +237,8 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual = testSuiteParserController.generateMockSections(true);
 
@@ -270,21 +274,25 @@ public class MockingTest {
         expected.add("      *Sections called when mocking");
         expected.add("      *****************************************************************");
         expected.add("       1-1-1-MOCK SECTION.");
+        expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
         expected.add(str4);
         expected.add(str5);
         expected.add("       .");
         expected.add("");
         expected.add("       1-1-2-MOCK SECTION.");
+        expected.add("           ADD 1 TO UT-1-1-2-MOCK-COUNT");
         expected.add(str8);
         expected.add(str9);
         expected.add("       .");
         expected.add("");
         expected.add("       1-2-1-MOCK SECTION.");
+        expected.add("           ADD 1 TO UT-1-2-1-MOCK-COUNT");
         expected.add(str13);
         expected.add(str14);
         expected.add("       .");
         expected.add("");
         expected.add("       2-1-1-MOCK SECTION.");
+        expected.add("           ADD 1 TO UT-2-1-1-MOCK-COUNT");
         expected.add(str19);
         expected.add(str20);
         expected.add("       .");
@@ -294,7 +302,8 @@ public class MockingTest {
                 str7, str8, str9, str10, str11, str12, str13, str14, str15, str16, str17, str18, str19,
                 str20, str21, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual = testSuiteParserController.generateMockSections(false);
 
@@ -317,7 +326,8 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START");
 
@@ -341,7 +351,8 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START");
 
@@ -398,7 +409,8 @@ public class MockingTest {
                 str7, str8, str9, str10, str11, str12, str13, str14, str15, str16, str17, str18, str19,
                 str20, str21, str22, str23, str24, str25, null);
 
-        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
 
         List<String> actual1 = testSuiteParserController.generateMockPerformCalls("000-START");
         List<String> actual2 = testSuiteParserController.generateMockPerformCalls("100-START");

--- a/src/test/java/com/neopragma/cobolcheck/MockingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockingTest.java
@@ -45,11 +45,11 @@ public class MockingTest {
 
     @BeforeEach
     void commonSetup() {
-        testSuiteParser = new TestSuiteParser(new KeywordExtractor());
+        mockRepository = new MockRepository();
+        testSuiteParser = new TestSuiteParser(new KeywordExtractor(), mockRepository);
         mockedReader = Mockito.mock(BufferedReader.class);
         testSuiteParserController = new TestSuiteParserController(mockedReader);
         cobolWriter = new CobolWriter(mockTestProgramSource);
-        mockRepository = new MockRepository();
     }
 
     @Test
@@ -63,7 +63,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals(1, mockRepository.getMocks().size());
     }
 
@@ -78,7 +78,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("000-START", mockRepository.getMocks().get(0).getIdentifier());
     }
 
@@ -110,7 +110,7 @@ public class MockingTest {
                 str7, str8, str9, str10, str11, str12, str13, str14, str15, str16, str17, str18, str19,
                 str20, str21, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("1-1-1-MOCK", mockRepository.getMocks().get(0).getGeneratedMockIdentifier());
         assertEquals("1-1-2-MOCK", mockRepository.getMocks().get(1).getGeneratedMockIdentifier());
         assertEquals("1-2-1-MOCK", mockRepository.getMocks().get(2).getGeneratedMockIdentifier());
@@ -128,7 +128,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("SECTION", mockRepository.getMocks().get(0).getType());
     }
 
@@ -147,7 +147,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals(expected, mockRepository.getMocks().get(0).getLines());
     }
 
@@ -161,7 +161,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("Global", mockRepository.getMocks().get(0).getScope().name());
     }
 
@@ -176,7 +176,7 @@ public class MockingTest {
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
-        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields, mockRepository);
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("Local", mockRepository.getMocks().get(0).getScope().name());
     }
 
@@ -419,6 +419,79 @@ public class MockingTest {
         assertEquals(expected2, actual2);
     }
 
+    @Test
+    public void it_generates_working_storage_mock_counting_fields_correctly() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK SECTION 000-START";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("       01  UT-MOCKS-GENERATED.");
+        expected.add("           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.");
+        expected.add("           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.");
+        expected.add("           05  UT-1-1-1-MOCK-NAME        PIC X(20)");
+        expected.add("                   VALUE \"SECTION 000-START\".");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParserController.parseTestSuites(numericFields);
+
+        List<String> actual = testSuiteParserController.generateMockCountingFields();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void it_generates_lines_for_initialize_mock_count_section_correctly() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       MOCK SECTION 000-START";
+        String str3 = "          MOVE \"global\" TO this";
+        String str4 = "          MOVE \"mock\" TO other";
+        String str5 = "       END-MOCK";
+        String str6 = "       TESTCASE \"Name of test case\"";
+        String str7 = "       MOCK SECTION 000-START";
+        String str8 = "          MOVE \"something\" TO this";
+        String str9 = "          MOVE \"something else\" TO other";
+        String str10 = "       END-MOCK";
+        String str11 = "       MOCK SECTION 100-START";
+        String str12 = "          MOVE \"hey\" TO greeting";
+        String str13 = "          MOVE \"bye\" TO greeting2";
+        String str14 = "       END-MOCK";
+        String str15 = "       TESTCASE \"test case 2\"";
+        String str16 = "       MOCK SECTION 000-START";
+        String str17 = "          ADD 1 TO WS-COUNT";
+        String str18 = "          MOVE \"something else\" TO other";
+        String str19 = "       END-MOCK";
+        String str20 = "       TESTSUITE \"Test suite 2\"";
+        String str21 = "       MOCK SECTION 000-START";
+        String str22 = "          MOVE \"something\" TO this";
+        String str23 = "          ADD 1 TO WS-COUNT";
+        String str24 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("       UT-INITIALIZE-MOCK-COUNT SECTION.");
+        expected.add("      *****************************************************************");
+        expected.add("      *Sets all global mock counters and expected count to 0");
+        expected.add("      *****************************************************************");
+        expected.add("           MOVE 0 TO UT-1-0-1-MOCK-COUNT");
+        expected.add("           MOVE 0 TO UT-1-0-1-MOCK-EXPECTED");
+        expected.add("           MOVE 0 TO UT-2-0-1-MOCK-COUNT");
+        expected.add("           MOVE 0 TO UT-2-0-1-MOCK-EXPECTED");
+        expected.add("       .");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6,
+                str7, str8, str9, str10, str11, str12, str13, str14, str15, str16, str17, str18, str19,
+                str20, str21, str22, str23, str24, null);
+
+        testSuiteParserController.parseTestSuites(numericFields);
+
+        List<String> actual = testSuiteParserController.generateMockCountInitializer();
+
+        assertEquals(expected, actual);
+    }
 
 
 

--- a/src/test/java/com/neopragma/cobolcheck/MockingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockingTest.java
@@ -203,7 +203,40 @@ public class MockingTest {
 
         testSuiteParserController.getProcedureDivisionTestCode(numericFields);
 
-        List<String> actual = testSuiteParserController.generateMockSections();
+        List<String> actual = testSuiteParserController.generateMockSections(false);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void single_mock_section_gets_generated_correctly_with_comment() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK SECTION 000-START";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("      *****************************************************************");
+        expected.add("      *Sections called when mocking");
+        expected.add("      *****************************************************************");
+        expected.add("       1-1-1-MOCK SECTION.");
+        expected.add("      *****************************************************************");
+        expected.add("      *Local mock of: SECTION: 000-START");
+        expected.add("      *In testsuite: \"Name of test suite\"");
+        expected.add("      *In testcase: \"Name of test case\"");
+        expected.add("      *****************************************************************");
+        expected.add(str4);
+        expected.add(str5);
+        expected.add("       .");
+        expected.add("");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParserController.getProcedureDivisionTestCode(numericFields);
+
+        List<String> actual = testSuiteParserController.generateMockSections(true);
 
         assertEquals(expected, actual);
     }
@@ -263,7 +296,7 @@ public class MockingTest {
 
         testSuiteParserController.getProcedureDivisionTestCode(numericFields);
 
-        List<String> actual = testSuiteParserController.generateMockSections();
+        List<String> actual = testSuiteParserController.generateMockSections(false);
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/com/neopragma/cobolcheck/TestSuiteParserCodeInsertionTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/TestSuiteParserCodeInsertionTest.java
@@ -1,5 +1,6 @@
 package com.neopragma.cobolcheck;
 
+import com.neopragma.cobolcheck.features.testSuiteParser.MockRepository;
 import com.neopragma.cobolcheck.features.writer.CobolWriter;
 import com.neopragma.cobolcheck.features.testSuiteParser.KeywordExtractor;
 import com.neopragma.cobolcheck.services.StringHelper;
@@ -242,7 +243,7 @@ public class TestSuiteParserCodeInsertionTest {
         mockedConfig = Mockito.mockStatic(Config.class);
         mockedConfig.when(() ->Config.getString(Constants.COBOLCHECK_PREFIX_CONFIG_KEY, Constants.DEFAULT_COBOLCHECK_PREFIX))
                 .thenReturn("UT-");
-        testSuiteParser = new TestSuiteParser(new KeywordExtractor());
+        testSuiteParser = new TestSuiteParser(new KeywordExtractor(), new MockRepository());
     }
 
     @AfterEach
@@ -251,7 +252,7 @@ public class TestSuiteParserCodeInsertionTest {
     }
 
     @Test
-    public void it_recognizes_the_end_of_a_user_written_cobol_statement_when_it_encounters_a_cobolcheck_keyword_that_can_follow_a_user_written_statement() throws IOException {
+    public void it_recognizes_the_end_of_a_user_written_cobol_statement_when_it_encounters_a_cobolcheck_keyword_that_can_follow_a_user_written_statement() {
         List<String> actualResult;
         List<String> expectedResult = new ArrayList<>();
         String testSuite = "            MOVE \"alpha\" TO WS-FIELDNAME                                           " +
@@ -264,7 +265,7 @@ public class TestSuiteParserCodeInsertionTest {
         expectedResult.add(expected2);
 
         BufferedReader testSuiteReader = new BufferedReader(new StringReader(testSuite));
-        actualResult = testSuiteParser.getParsedTestSuiteLines(testSuiteReader, numericFields, null);
+        actualResult = testSuiteParser.getParsedTestSuiteLines(testSuiteReader, numericFields);
 
         assertEquals(expectedResult, actualResult);
     }
@@ -294,9 +295,11 @@ public class TestSuiteParserCodeInsertionTest {
         String expected1 = "           MOVE \"Test Case Name\"";
         String expected2 = "               TO UT-TEST-CASE-NAME";
         String expected3 = "           PERFORM UT-BEFORE";
+        String expected4 = "           PERFORM UT-INITIALIZE-MOCK-COUNT";
         expectedResult.add(expected1);
         expectedResult.add(expected2);
         expectedResult.add(expected3);
+        expectedResult.add(expected4);
 
         testSuiteParser.addTestCaseNameLines("\"Test Case Name\"", actualResult);
         assertEquals(expectedResult, actualResult);
@@ -318,7 +321,7 @@ public class TestSuiteParserCodeInsertionTest {
             String testSuiteInput,
             String fieldName,
             DataType dataType,
-            String expectedResult) throws IOException {
+            String expectedResult) {
 
         List<String> actualResult;
         List<String> expectedResultList = new ArrayList<>();
@@ -329,7 +332,7 @@ public class TestSuiteParserCodeInsertionTest {
 
         lenient().doReturn(dataType).when(numericFields).dataTypeOf(fieldName);
         BufferedReader testSuiteReader = new BufferedReader(new StringReader(testSuiteInput));
-        actualResult = testSuiteParser.getParsedTestSuiteLines(testSuiteReader, numericFields, null);
+        actualResult = testSuiteParser.getParsedTestSuiteLines(testSuiteReader, numericFields);
         assertEquals(expectedResultList, actualResult);
     }
     private static Stream<Arguments> expectationCheckProvider() {

--- a/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
@@ -1,5 +1,8 @@
 package com.neopragma.cobolcheck;
 
+import com.neopragma.cobolcheck.exceptions.PossibleInternalLogicErrorException;
+import com.neopragma.cobolcheck.exceptions.VerifyReferencesNonexistentMockException;
+import com.neopragma.cobolcheck.features.argumentHandler.ArgumentHandler;
 import com.neopragma.cobolcheck.features.testSuiteParser.MockRepository;
 import com.neopragma.cobolcheck.features.writer.CobolWriter;
 import com.neopragma.cobolcheck.features.testSuiteParser.KeywordExtractor;
@@ -17,8 +20,11 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @ExtendWith(MockitoExtension.class)
 public class TestSuiteParserParsingTest {
@@ -39,97 +45,332 @@ public class TestSuiteParserParsingTest {
 
     @BeforeEach
     void commonSetup() {
-        testSuiteParser = new TestSuiteParser(new KeywordExtractor());
+        mockRepository = new MockRepository();
+        testSuiteParser = new TestSuiteParser(new KeywordExtractor(), mockRepository);
         testSuite = new StringBuilder();
         cobolWriter = new CobolWriter(mockTestProgramSource);
-        mockRepository = new MockRepository();
     }
 
     @Test
-    public void it_stores_the_name_of_the_test_suite_after_detecting_the_TESTSUITE_keyword() throws IOException {
+    public void it_stores_the_name_of_the_test_suite_after_detecting_the_TESTSUITE_keyword() {
         testSuite.append("       TESTSUITE \"Name of test suite\"");
         testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals("\"Name of test suite\"", testSuiteParser.getCurrentTestSuiteName());
     }
 
     @Test
-    public void it_stores_the_name_of_a_test_case_after_detecting_the_TESTCASE_keyword() throws IOException {
+    public void it_stores_the_name_of_a_test_case_after_detecting_the_TESTCASE_keyword() {
         testSuite.append("       TESTCASE \"Name of test case\"");
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals("\"Name of test case\"", testSuiteParser.getCurrentTestCaseName());
     }
 
     @Test
-    public void it_parses_a_user_written_cobol_statement_written_on_a_single_line_with_no_period() throws IOException {
+    public void it_parses_a_user_written_cobol_statement_written_on_a_single_line_with_no_period() {
         String expectedResult = "            MOVE \"alpha\" TO WS-FIELDNAME";
         testSuite.append(expectedResult);
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_parses_a_user_written_cobol_statement_written_on_a_single_line_terminated_by_a_period() throws IOException {
+    public void it_parses_a_user_written_cobol_statement_written_on_a_single_line_terminated_by_a_period() {
         String expectedResult = "            MOVE \"alpha\" TO WS-FIELDNAME";
         testSuite.append(expectedResult);
         testSuite.append(".");
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_parses_a_user_written_cobol_statement_written_on_multiple_lines_with_no_period() throws IOException {
+    public void it_parses_a_user_written_cobol_statement_written_on_multiple_lines_with_no_period() {
         String expectedResult = "            MOVE \"alpha\" TO WS-FIELDNAME";
         testSuite.append("            MOVE \n\"alpha\" \nTO WS-FIELDNAME");
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_parses_a_user_written_cobol_statement_written_on_multiple_lines_terminated_by_a_period() throws IOException {
+    public void it_parses_a_user_written_cobol_statement_written_on_multiple_lines_terminated_by_a_period() {
         String expectedResult = "            MOVE \"alpha\" TO WS-FIELDNAME";
         testSuite.append("            MOVE \n\"alpha\" \nTO WS-FIELDNAME.");
         testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_recognizes_the_start_of_a_user_written_cobol_statement_when_it_encounters_a_cobol_verb() throws Exception {
+    public void it_recognizes_the_start_of_a_user_written_cobol_statement_when_it_encounters_a_cobol_verb() {
         String expectedResult = "            MULTIPLY WS-TAXABLE-SUBTOTAL BY WS-SALES-TAX-RATE GIVING WS-TOTAL";
         testSuite.append("           MOVE \"first thing\" TO WS-FIELD-1\n");
         testSuite.append(expectedResult);
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_captures_a_simple_item_name_from_an_EXPECT() throws Exception {
+    public void it_captures_a_simple_item_name_from_an_EXPECT() {
         String expectedResult = "            WS-FIELDNAME";
         testSuite.append("           EXPECT WS-FIELDNAME TO BE \"some value\"");
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
 
     @Test
-    public void it_captures_a_qualified_item_name_from_an_EXPECT() throws Exception {
+    public void it_captures_a_qualified_item_name_from_an_EXPECT() {
         String expectedResult = "            WS-FIELDNAME OF WS-GROUP";
         testSuite.append("           EXPECT WS-FIELDNAME OF WS-GROUP TO BE \"some value\"");
         testSuiteParser.getParsedTestSuiteLines(
                 new BufferedReader(new StringReader(testSuite.toString())),
-                numericFields, mockRepository);
+                numericFields);
         assertEquals(expectedResult, testSuiteParser.getCobolStatement());
     }
+
+    @Test
+    public void it_generates_lines_for_verify_statement_with_exact_comparison() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED 1 TIME");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_generates_lines_for_verify_statement_with_at_least_comparison() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED AT LEAST ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-AT-LEAST TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_generates_lines_for_verify_statement_with_no_more_than_comparison() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED NO MORE THAN 2 TIMES");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 2 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-NO-MORE-THAN TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_generates_lines_for_verify_never_happened_statement() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       VERIFY SECTION 000-START NEVER HAPPENED");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 0 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_generates_lines_for_verify_no_more_than_once_statement() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED NO MORE THAN ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-NO-MORE-THAN TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_generates_lines_for_verify_happened_once_statement() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void if_local_and_global_mock_exists_in_scope_verify_attaches_to_local() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"global\" TO this");
+        testSuite.append("          MOVE \"global, global\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED ONCE");
+
+        //Global mock would be named UT-1-0-1-MOCK
+        String expectedFirstLine = "           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED";
+
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedFirstLine, actualResult.get(0));
+    }
+
+    @Test
+    public void verify_can_attach_to_global_mock() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       VERIFY SECTION 000-START HAPPENED ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-0-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-0-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-0-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-0-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_throws_if_the_mock_that_verify_references_does_not_exist() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK SECTION 000-START");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append( "       END-MOCK");
+        testSuite.append( "       VERIFY SECTION 100-WELCOME HAPPENED ONCE");
+
+        String expectedResult = "Cannot verify nonexistent mock for: 100-WELCOME in the scope of testsuite:" +
+                " \"Name of test suite\", testcase: \"Name of test case\"";
+
+        Throwable ex = assertThrows(VerifyReferencesNonexistentMockException.class, () ->
+                testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                        numericFields));
+        assertEquals(expectedResult, ex.getMessage());
+    }
+
+
+
+
 }


### PR DESCRIPTION
This pull request builds upon #156, as that has not been merged into main yet.

Some variables declared in CCHECKWS.CPY, is- and will not be used, as most of the functionality pertaining to mocking, is now implemented in java. Thus several variables should be removed. As I am not familiar with most of the variables declared in this copy-book, I have not taken on this task.

### Added classes:
- Added and implemented `VerifyMockCount.`
- Added and implemented `VerifyReferencesNonexistentMockException`

### Changes in copybooks:
**CCHECKWS.CPY:**
- Added `==UT==LABEL-VERIFY-COMPARE`
- Added Strings for comparison (Exact, At least, No more than)

**CCHECKPD.CPY:**
- In Assert-Access pargraph, the right comparison string is now moved to `==UT==LABEL-VERIFY-COMPARE`
- Assert-Access paragraph don't check mock types before displaying anymore
- Assert-Access paragraph now displays the current compare, type and identifier
- `==UT==SET-MOCK` is deleted, as this functionality is implemented in Java
- `==UT==SET-FILE-MOCK` is deleted, as this functionality is going to be implemented in Java
- `==UT==SET-CALL-MOCK` is deleted, as this functionality is going to be implemented in Java
- `==UT==SET-CICS-MOCK` is deleted, as this functionality is going to be implemented in Java
- `==UT==SET-PARA-MOCK` is deleted, as this functionality is going to be implemented in Java
- `==UT==LOOKUP-MOCK` is deleted, as this functionality is implemented in Java
- `==UT==LOOKUP-MOCK` is deleted, as this functionality is implemented in Java

### General changes:
- Added constant variables in `Constants` for parsing `VERIFY` statement
- Added multiword tokens in `KeywordExtractor.`
- Changed `KeywordExtractor.extractTokensFrom`, to handle more than two-word tokens.
- Added keywords for `VERIFY-statements` to map in Keywords.
-  Expected count and string identifier is now generated in cobol for each mock.
 - Added some extra `PERFORM`s and different `VERIFY`-statements, to `MockTest`, to test the implementation.
 - Added functionality in `TestSuiteParser `to parse a VERIFY-statement.
- Added tests to `MockingTest`
- Added tests to `TestSuiteParserParsingTest`
- Some tests has been slightly altered to comply with changes
- Added method descriptions for substantial methods