### PR TITLE
Call statement mock

### DIFF
--- a/approval-test-expected.txt
+++ b/approval-test-expected.txt
@@ -150,30 +150,46 @@ General tests
      PASS:  13. Switches values
      PASS:  14. Switches values
 TESTSUITE:
-Mocking tests
-     PASS:  15. Global mock behaves as intended
-     PASS:  16. Global mock behaves as intended
-     PASS:  17. VERIFY EXACT           1 ACCESS   TO SECTION 000-START
-     PASS:  18. Local mock overwrites global mock
-     PASS:  19. Local mock overwrites global mock
-     PASS:  20. VERIFY AT LEAST        2 ACCESSES TO SECTION 000-START
-     PASS:  21. Multiple local mocks behaves as intended
-     PASS:  22. Multiple local mocks behaves as intended
-**** FAIL:  23. VERIFY ACCESSES TO SECTION 000-START
+Mock Call statements test
+     PASS:  15. Simple call mock works
+     PASS:  16. Simple call mock works
+     PASS:  17. Simple global call mock works
+     PASS:  18. Simple global call mock works
+     PASS:  19. Call mock with argument works
+     PASS:  20. Call mock with argument works
+     PASS:  21. Call mock with content reference for arguments work
+     PASS:  22. Call mock with content reference for arguments work
+     PASS:  23. Call mock with content reference for arguments work
+     PASS:  24. Paragraph mock is called and call mock is ignored
+     PASS:  25. Paragraph mock is called and call mock is ignored
+     PASS:  26. Paragraph mock is called and call mock is ignored
+**** FAIL:  27. Global call mock is not overwritten by local call mock (Should fail)
+    EXPECTED <Global PROG1>, WAS <Local PROG1>
+TESTSUITE:
+Mock Sections And Paragraphs
+     PASS:  28. Global mock behaves as intended
+     PASS:  29. Global mock behaves as intended
+     PASS:  30. VERIFY EXACT           1 ACCESS   TO SECTION 000-START
+     PASS:  31. Local mock overwrites global mock
+     PASS:  32. Local mock overwrites global mock
+     PASS:  33. VERIFY AT LEAST        2 ACCESSES TO SECTION 000-START
+     PASS:  34. Multiple local mocks behaves as intended (First Verify should fail)
+     PASS:  35. Multiple local mocks behaves as intended (First Verify should fail)
+**** FAIL:  36. VERIFY ACCESSES TO SECTION 000-START
    EXPECTED EXACT            5 ACCESSES, WAS     2
-     PASS:  24. VERIFY NO MORE THAN   10 ACCESSES TO SECTION 100-WELCOME
-     PASS:  25. VERIFY EXACT           0 ACCESSES TO PARAGRAPH 500-SWITCH
-     PASS:  26. Empty local mock makes section do nothing
-     PASS:  27. Empty local mock makes section do nothing
-     PASS:  28. VERIFY EXACT           1 ACCESS   TO PARAGRAPH 500-SWITCH
-     PASS:  29. Local and global mocks can be used together
-     PASS:  30. Local and global mocks can be used together
-     PASS:  31. If no local or global mock run source code
-     PASS:  32. If no local or global mock run source code
-     PASS:  33. Global paragraph mock works
-     PASS:  34. Global paragraph mock works
+     PASS:  37. VERIFY NO MORE THAN   10 ACCESSES TO SECTION 100-WELCOME
+     PASS:  38. VERIFY EXACT           0 ACCESSES TO PARAGRAPH 500-SWITCH
+     PASS:  39. Empty local mock makes section do nothing
+     PASS:  40. Empty local mock makes section do nothing
+     PASS:  41. VERIFY EXACT           1 ACCESS   TO PARAGRAPH 500-SWITCH
+     PASS:  42. Local and global mocks can be used together
+     PASS:  43. Local and global mocks can be used together
+     PASS:  44. If no local or global mock run source code
+     PASS:  45. If no local or global mock run source code
+     PASS:  46. Global paragraph mock works
+     PASS:  47. Global paragraph mock works
 
- 34 TEST CASES WERE EXECUTED
- 33 PASSED
-  1 FAILED
+ 47 TEST CASES WERE EXECUTED
+ 45 PASSED
+  2 FAILED
 =================================================

--- a/approval-test-expected.txt
+++ b/approval-test-expected.txt
@@ -153,43 +153,49 @@ TESTSUITE:
 Mock Call statements test
      PASS:  15. Simple call mock works
      PASS:  16. Simple call mock works
-     PASS:  17. Simple global call mock works
+     PASS:  17. VERIFY EXACT           1 ACCESS   TO CALL 'PROG1'
      PASS:  18. Simple global call mock works
-     PASS:  19. Call mock with argument works
-     PASS:  20. Call mock with argument works
-     PASS:  21. Call mock with content reference for arguments work
-     PASS:  22. Call mock with content reference for arguments work
-     PASS:  23. Call mock with content reference for arguments work
-     PASS:  24. Paragraph mock is called and call mock is ignored
-     PASS:  25. Paragraph mock is called and call mock is ignored
-     PASS:  26. Paragraph mock is called and call mock is ignored
-**** FAIL:  27. Global call mock is not overwritten by local call mock (Should fail)
+     PASS:  19. Simple global call mock works
+     PASS:  20. VERIFY EXACT           1 ACCESS   TO CALL 'PROG1'
+     PASS:  21. Call mock with argument works
+     PASS:  22. Call mock with argument works
+     PASS:  23. VERIFY EXACT           1 ACCESS   TO CALL VALUE-2
+     PASS:  24. Call mock with content reference for arguments work
+     PASS:  25. Call mock with content reference for arguments work
+     PASS:  26. Call mock with content reference for arguments work
+     PASS:  27. VERIFY EXACT           2 ACCESSES TO CALL 'PROG3'
+     PASS:  28. Paragraph mock is called and call mock is ignored
+     PASS:  29. Paragraph mock is called and call mock is ignored
+     PASS:  30. Paragraph mock is called and call mock is ignored
+     PASS:  31. VERIFY EXACT           1 ACCESS   TO PARAGRAPH 800-MAKE-CALL
+     PASS:  32. VERIFY EXACT           0 ACCESSES TO CALL 'PROG3'
+**** FAIL:  33. Global call mock is not overwritten by local call mock (Should fail)
     EXPECTED <Global PROG1>, WAS <Local PROG1>
 TESTSUITE:
 Mock Sections And Paragraphs
-     PASS:  28. Global mock behaves as intended
-     PASS:  29. Global mock behaves as intended
-     PASS:  30. VERIFY EXACT           1 ACCESS   TO SECTION 000-START
-     PASS:  31. Local mock overwrites global mock
-     PASS:  32. Local mock overwrites global mock
-     PASS:  33. VERIFY AT LEAST        2 ACCESSES TO SECTION 000-START
-     PASS:  34. Multiple local mocks behaves as intended (First Verify should fail)
-     PASS:  35. Multiple local mocks behaves as intended (First Verify should fail)
-**** FAIL:  36. VERIFY ACCESSES TO SECTION 000-START
+     PASS:  34. Global mock behaves as intended
+     PASS:  35. Global mock behaves as intended
+     PASS:  36. VERIFY EXACT           1 ACCESS   TO SECTION 000-START
+     PASS:  37. Local mock overwrites global mock
+     PASS:  38. Local mock overwrites global mock
+     PASS:  39. VERIFY AT LEAST        2 ACCESSES TO SECTION 000-START
+     PASS:  40. Multiple local mocks behaves as intended (First Verify should fail)
+     PASS:  41. Multiple local mocks behaves as intended (First Verify should fail)
+**** FAIL:  42. VERIFY ACCESSES TO SECTION 000-START
    EXPECTED EXACT            5 ACCESSES, WAS     2
-     PASS:  37. VERIFY NO MORE THAN   10 ACCESSES TO SECTION 100-WELCOME
-     PASS:  38. VERIFY EXACT           0 ACCESSES TO PARAGRAPH 500-SWITCH
-     PASS:  39. Empty local mock makes section do nothing
-     PASS:  40. Empty local mock makes section do nothing
-     PASS:  41. VERIFY EXACT           1 ACCESS   TO PARAGRAPH 500-SWITCH
-     PASS:  42. Local and global mocks can be used together
-     PASS:  43. Local and global mocks can be used together
-     PASS:  44. If no local or global mock run source code
-     PASS:  45. If no local or global mock run source code
-     PASS:  46. Global paragraph mock works
-     PASS:  47. Global paragraph mock works
+     PASS:  43. VERIFY NO MORE THAN   10 ACCESSES TO SECTION 100-WELCOME
+     PASS:  44. VERIFY EXACT           0 ACCESSES TO PARAGRAPH 500-SWITCH
+     PASS:  45. Empty local mock makes section do nothing
+     PASS:  46. Empty local mock makes section do nothing
+     PASS:  47. VERIFY EXACT           1 ACCESS   TO PARAGRAPH 500-SWITCH
+     PASS:  48. Local and global mocks can be used together
+     PASS:  49. Local and global mocks can be used together
+     PASS:  50. If no local or global mock run source code
+     PASS:  51. If no local or global mock run source code
+     PASS:  52. Global paragraph mock works
+     PASS:  53. Global paragraph mock works
 
- 47 TEST CASES WERE EXECUTED
- 45 PASSED
+ 53 TEST CASES WERE EXECUTED
+ 51 PASSED
   2 FAILED
 =================================================

--- a/src/main/cobol/MOCKTEST.CBL
+++ b/src/main/cobol/MOCKTEST.CBL
@@ -11,6 +11,7 @@
        01  FILLER.
            05  VALUE-1           PIC X(80).
            05  VALUE-2           PIC X(80).
+           05  VALUE-3           PIC X(80).
            05  TEMP              PIC X(80).
 
        PROCEDURE DIVISION.
@@ -54,7 +55,7 @@
 
        400-CHANGE-2
           .
-          EVALUATE VALUE-2
+           EVALUATE VALUE-2
            WHEN "Hi"
               MOVE "See you" TO VALUE-2
            WHEN OTHER
@@ -66,6 +67,31 @@
            MOVE VALUE-2 TO TEMP
            MOVE VALUE-1 TO VALUE-2
            MOVE TEMP TO VALUE-1.
+
+       600-MAKE-CALL.
+           MOVE "arg1" to VALUE-1
+           MOVE "arg2" to VALUE-2
+           CALL 'PROG1'
+           .
+
+       700-MAKE-CALL.
+           MOVE "arg1" to VALUE-1
+           MOVE "arg2" to VALUE-2
+           CALL VALUE-2 USING VALUE-1
+           END-CALL.
+
+       800-MAKE-CALL.
+           MOVE "arg1" to VALUE-1
+           MOVE "arg2" to VALUE-2
+           MOVE "arg3" to VALUE-3
+           CALL 'PROG3' USING 
+              BY CONTENT VALUE-1,
+              BY VALUE VALUE-2,  
+              VALUE-3.
+           CALL 'PROG3' USING 
+              BY CONTENT VALUE-1,
+              BY VALUE VALUE-2,  
+              VALUE-3.
 
        999-END.
            GOBACK

--- a/src/main/java/com/neopragma/cobolcheck/features/interpreter/CobolReader.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/interpreter/CobolReader.java
@@ -1,6 +1,8 @@
 package com.neopragma.cobolcheck.features.interpreter;
 
 import com.neopragma.cobolcheck.exceptions.PossibleInternalLogicErrorException;
+import com.neopragma.cobolcheck.services.cobolLogic.CobolLine;
+import com.neopragma.cobolcheck.services.cobolLogic.Interpreter;
 import com.neopragma.cobolcheck.services.cobolLogic.TokenExtractor;
 
 import java.io.*;
@@ -133,6 +135,14 @@ public class CobolReader {
                 return cobolLine;
             }
         }
+    }
+
+    void putNextLine(CobolLine line){
+        nextLines.add(0, line);
+    }
+
+    void putNextLine(String line){
+        nextLines.add(0, new CobolLine(line, tokenExtractor));
     }
 
     /**

--- a/src/main/java/com/neopragma/cobolcheck/features/interpreter/State.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/interpreter/State.java
@@ -48,6 +48,7 @@ public class State {
         flags.put(Constants.COPY_TOKEN, new Flag());
         flags.put(Constants.SECTION_TOKEN, new Flag());
         flags.put(Constants.PARAGRAPH_TOKEN, new Flag());
+        flags.put(Constants.CALL_TOKEN, new Flag());
 
 //IDENTIFICATION_DIVISION
         mutuallyExclusiveFlagsFor(Constants.IDENTIFICATION_DIVISION,
@@ -122,8 +123,13 @@ public class State {
                 Constants.IDENTIFICATION_DIVISION, Constants.ENVIRONMENT_DIVISION, Constants.DATA_DIVISION);
 
 // SECTION
-        dependentFlagsFor(Constants.SECTION_TOKEN,
-                Constants.PARAGRAPH_TOKEN);
+        mutuallyExclusiveFlagsFor(Constants.SECTION_TOKEN,
+                Constants.PARAGRAPH_TOKEN, Constants.CALL_TOKEN);
+
+// CALL
+        mutuallyExclusiveFlagsFor(Constants.CALL_TOKEN,
+                Constants.PARAGRAPH_TOKEN, Constants.SECTION_TOKEN);
+
     }
 
     public Map<String, Flag> getFlags() {

--- a/src/main/java/com/neopragma/cobolcheck/features/interpreter/StringTokenizerExtractor.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/interpreter/StringTokenizerExtractor.java
@@ -52,6 +52,7 @@ public class StringTokenizerExtractor implements TokenExtractor {
         expectedTokens.put("LINKAGE", Arrays.asList("SECTION"));
         expectedTokens.put("WORKING-STORAGE", Arrays.asList("SECTION"));
         expectedTokens.put("LOCAL-STORAGE", Arrays.asList("SECTION"));
+        expectedTokens.put("BY", Arrays.asList("REFERENCE", "CONTENT", "VALUE"));
     }
 
     /**

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/KeywordExtractor.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/KeywordExtractor.java
@@ -40,6 +40,7 @@ public class KeywordExtractor implements TokenExtractor {
         multiWordTokens.put("NEVER", Arrays.asList("HAPPENED"));
         multiWordTokens.put("AT", Arrays.asList("LEAST"));
         multiWordTokens.put("NO", Arrays.asList("MORE", "THAN"));
+        multiWordTokens.put("BY", Arrays.asList("REFERENCE", "CONTENT", "VALUE"));
 
     }
 

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Keywords.java
@@ -152,6 +152,25 @@ public class Keywords {
                 new Keyword(Constants.MOCK_TYPE,
                         Arrays.asList(Constants.COBOL_TOKEN),
                         KeywordAction.NONE));
+        keywordInfo.put(Constants.USING_TOKEN,
+                new Keyword(Constants.USING_TOKEN,
+                        Arrays.asList(Constants.COBOL_TOKEN,
+                                Constants.BY_REFERENCE_TOKEN,
+                                Constants.BY_CONTENT_TOKEN,
+                                Constants.BY_VALUE_TOKEN),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.BY_REFERENCE_TOKEN,
+                new Keyword(Constants.BY_REFERENCE_TOKEN,
+                        Arrays.asList(Constants.COBOL_TOKEN),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.BY_CONTENT_TOKEN,
+                new Keyword(Constants.BY_CONTENT_TOKEN,
+                        Arrays.asList(Constants.COBOL_TOKEN),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.BY_VALUE_TOKEN,
+                new Keyword(Constants.BY_VALUE_TOKEN,
+                        Arrays.asList(Constants.COBOL_TOKEN),
+                        KeywordAction.NONE));
         keywordInfo.put(Constants.VERIFY_KEYWORD,
                 new Keyword(Constants.VERIFY_KEYWORD,
                         Arrays.asList(Constants.MOCK_TYPE),
@@ -187,7 +206,7 @@ public class Keywords {
                         KeywordAction.NONE));
 
         //TODO: Add other types that can be mocked
-        mockTypes = Arrays.asList(Constants.SECTION_TOKEN, Constants.PARAGRAPH_TOKEN);
+        mockTypes = Arrays.asList(Constants.SECTION_TOKEN, Constants.PARAGRAPH_TOKEN, Constants.CALL_TOKEN);
     }
 
 

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -7,6 +7,7 @@ public class Mock {
     private String identifier;
     private String type;
     private List<String> lines;
+    private List<String> arguments;
     private MockScope scope;
     private boolean isUsed;
     private String testSuiteName;
@@ -22,6 +23,7 @@ public class Mock {
         this.testCaseNumber = testCaseNumber;
         this.mockNumber = mockNumber;
         lines = new ArrayList<>();
+        arguments = new ArrayList<>();
     }
 
     public String getGeneratedMockIdentifier(){
@@ -53,6 +55,9 @@ public class Mock {
         List<String> lines = new ArrayList<>();
         lines.add("      *****************************************************************");
         lines.add(scope.name() + " mock of: " + type + ": " + identifier);
+        if (!arguments.isEmpty()){
+            lines.add("With args: " + getArgumentText());
+        }
         lines.add("In testsuite: " + testSuiteName);
         if (scope == MockScope.Local){
             lines.add("In testcase: " + testCaseName);
@@ -73,6 +78,8 @@ public class Mock {
     public List<String> getLines() {
         return lines;
     }
+
+    public List<String> getArguments() {return arguments;}
 
     public MockScope getScope() {
         return scope;
@@ -112,5 +119,15 @@ public class Mock {
 
     public void addLines(List<String> lines) {
         this.lines.addAll(lines);
+    }
+
+    public void addArgument(String argument) {arguments.add(argument);}
+
+    private String getArgumentText(){
+        String combinedArgs = "";
+        for (String arg : arguments){
+            combinedArgs += arg + ", ";
+        }
+        return combinedArgs.substring(0, combinedArgs.length() - 2);
     }
 }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -1,5 +1,6 @@
 package com.neopragma.cobolcheck.features.testSuiteParser;
 
+import com.neopragma.cobolcheck.services.Constants;
 import com.neopragma.cobolcheck.services.StringHelper;
 
 import java.util.ArrayList;
@@ -86,7 +87,7 @@ public class MockGenerator {
      * @param mocks - All mocks in all tests
      * @return The generated lines
      */
-    List<String> generateMockPerformCalls(String identifier, String type, List<Mock> mocks){
+    List<String> generateMockPerformCalls(String identifier, String type, List<String> arguments, List<Mock> mocks){
         List<String> resultLines = new ArrayList<>();
         List<String> localLines = new ArrayList<>();
         List<String> globalLines = new ArrayList<>();
@@ -97,7 +98,8 @@ public class MockGenerator {
         resultLines.add(evaluateStartLine);
 
         for (Mock mock: mocks) {
-            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)){
+            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)
+                    && mock.getArguments().equals(arguments)){
                 if (mock.getScope() == MockScope.Local){
                     localLines.add(String.format(whenFormat1, mock.getTestSuiteName()));
                     localLines.add(String.format(whenFormat2, mock.getTestCaseName()));
@@ -116,7 +118,10 @@ public class MockGenerator {
         // Thus we need to have local mocks on top of global mocks
         resultLines.addAll(localLines);
         resultLines.addAll(globalLines);
-        resultLines.add(whenOtherLine);
+        if (type.equals(Constants.SECTION_TOKEN) || type.equals(Constants.PARAGRAPH_TOKEN))
+            resultLines.add(whenOtherLine);
+        else
+            resultLines.add(getEndEvaluateLine());
 
         return resultLines;
     }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockRepository.java
@@ -15,7 +15,8 @@ public class MockRepository {
             throw new ComponentMockedTwiceInSameScopeException("Mock for " + mock.getIdentifier() + " in " +
                     "testsuite: " + mock.getTestSuiteName() + ", testcase: " +
                     ((mock.getTestCaseName().equals("")) ? "N/A" : mock.getTestCaseName()) +
-                    " already exists in this "+ mock.getScope().name() +
+                    " already exists " + (mock.getArguments().isEmpty() ? "" : "with the given arguments ") +
+                    "in this "+ mock.getScope().name() +
                     ((mock.getScope() == MockScope.Local) ? " testcase " : " testsuite ") + "scope.");
         }
         mocks.add(mock);
@@ -25,19 +26,21 @@ public class MockRepository {
         return mocks;
     }
 
-    public boolean mockExistsFor(String identifier, String type){
+    public boolean mockExistsFor(String identifier, String type, List<String> arguments){
         for (Mock mock: mocks) {
-            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)){
+            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)
+                    && mock.getArguments().equals(arguments)){
                 return true;
             }
         }
         return false;
     }
 
-    public Mock getMockFor(String identifier, String type, String testSuite, String testCase){
+    public Mock getMockFor(String identifier, String type, String testSuite, String testCase, List<String> arguments){
         List<Mock> globalMocks = new ArrayList<>();
         for (Mock mock: mocks) {
-            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)){
+            if (mock.getIdentifier().equals(identifier) && mock.getType().equals(type)
+                    && (mock.getArguments().equals(arguments))){
                 if (mock.getScope() == MockScope.Local){
                     if (mock.getTestSuiteName().equals(testSuite) && mock.getTestCaseName().equals(testCase)){
                         return mock;
@@ -54,17 +57,17 @@ public class MockRepository {
                 return mock;
             }
         }
-
-
         return null;
     }
+
 
     private boolean mockAlreadyExist(Mock mock){
         for(Mock m : mocks){
             if (mock.getIdentifier().equals(m.getIdentifier())
                     && mock.getScope() == m.getScope()
                     && mock.getTestSuiteName().equals(m.getTestSuiteName())
-                    && mock.getTestCaseName().equals(m.getTestCaseName())){
+                    && mock.getTestCaseName().equals(m.getTestCaseName())
+                    && mock.getArguments().equals(m.getArguments())) {
                 return true;
             }
         }

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
@@ -189,8 +189,8 @@ public class TestSuiteParserController {
         return mockGenerator.generateMockParagraphs(mockRepository.getMocks(), withComments);
     }
 
-    public boolean mockExistsFor(String identifier, String type){
-        return mockRepository.mockExistsFor(identifier, type);
+    public boolean mockExistsFor(String identifier, String type, List<String> arguments){
+        return mockRepository.mockExistsFor(identifier, type, arguments);
     }
 
     /**Generates the lines for 'Evaluate when' to perform the correct generated SECTION
@@ -198,8 +198,8 @@ public class TestSuiteParserController {
      * @param identifier - The identifier of the SECTION, PARAGRAPH etc. that is mocked.
      * @return The generated lines
      */
-    public List<String> generateMockPerformCalls(String identifier, String type){
-        return mockGenerator.generateMockPerformCalls(identifier, type, mockRepository.getMocks());
+    public List<String> generateMockPerformCalls(String identifier, String type, List<String> arguments){
+        return mockGenerator.generateMockPerformCalls(identifier, type, arguments, mockRepository.getMocks());
     }
     /**This line should be inserted at the end of a mocked component,
      * to end the EVALUATE started in the beginning of the mock.

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/VerifyMockCount.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/VerifyMockCount.java
@@ -1,5 +1,8 @@
 package com.neopragma.cobolcheck.features.testSuiteParser;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class VerifyMockCount{
     private Mock attachedMock;
     private String expectedCount = "0";
@@ -7,6 +10,11 @@ public class VerifyMockCount{
     private boolean noMoreThan;
     private String identifier;
     private String type;
+    private List<String> arguments;
+
+    public VerifyMockCount(){
+        arguments = new ArrayList<>();
+    }
 
     public String getExpectedCount() {
         return expectedCount;
@@ -62,5 +70,13 @@ public class VerifyMockCount{
         this.expectedCount = expectedCount;
         atLeast = false;
         noMoreThan = true;
+    }
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    public void addArgument(String argument) {
+        arguments.add(argument);
     }
 }

--- a/src/main/java/com/neopragma/cobolcheck/features/writer/CobolWriter.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/writer/CobolWriter.java
@@ -1,6 +1,6 @@
 package com.neopragma.cobolcheck.features.writer;
 
-import com.neopragma.cobolcheck.features.interpreter.Interpreter;
+import com.neopragma.cobolcheck.services.cobolLogic.Interpreter;
 import com.neopragma.cobolcheck.services.StringHelper;
 
 import java.io.IOException;

--- a/src/main/java/com/neopragma/cobolcheck/services/Constants.java
+++ b/src/main/java/com/neopragma/cobolcheck/services/Constants.java
@@ -122,10 +122,16 @@ public final class Constants {
     public static final String LEVEL_01_TOKEN = "01";
     public static final String COPY_TOKEN = "COPY";
     public static final String SECTION_TOKEN = "SECTION";
+    public static final String CALL_TOKEN = "CALL";
+    public static final String USING_TOKEN = "USING";
+    public static final String BY_REFERENCE_TOKEN = "BY REFERENCE";
+    public static final String BY_CONTENT_TOKEN = "BY CONTENT";
+    public static final String BY_VALUE_TOKEN = "BY VALUE";
     public static final String DECLARATIVES_TOKEN = "DECLARATIVES";
     public static final String EXIT_TOKEN = "EXIT";
     public static final String END_SECTION_TOKEN = "END-SECTION";
     public static final String END_PARAGRAPH_TOKEN = "END-PARAGRAPH";
+    public static final String END_CALL_TOKEN = "END-CALL";
     public static final String ZERO_TOKEN = "ZERO";
 
 

--- a/src/main/java/com/neopragma/cobolcheck/services/cobolLogic/CobolLine.java
+++ b/src/main/java/com/neopragma/cobolcheck/services/cobolLogic/CobolLine.java
@@ -1,4 +1,4 @@
-package com.neopragma.cobolcheck.features.interpreter;
+package com.neopragma.cobolcheck.services.cobolLogic;
 
 import com.neopragma.cobolcheck.services.StringHelper;
 import com.neopragma.cobolcheck.services.cobolLogic.TokenExtractor;
@@ -19,16 +19,16 @@ public class CobolLine {
         tokens = tokenExtractor.extractTokensFrom(line);
     }
 
-    String getOriginalString() {
+    public String getOriginalString() {
         return originalString;
     }
     public String getTrimmedString() { return trimmedString; }
-    List<String> getTokens() {
+    public List<String> getTokens() {
         return tokens;
     }
-    String getToken(int index) { return tokens.get(index); }
+    public String getToken(int index) { return tokens.get(index); }
 
-    int tokensSize() { return tokens.size(); }
+    public int tokensSize() { return tokens.size(); }
 
     /**
      * Checks if this line contains the specified string - not case-sensitive. The string
@@ -38,7 +38,23 @@ public class CobolLine {
      *
      * @return (boolean) true if this line contains the token
      */
-    boolean containsToken(String tokenValue) {
+    public boolean containsToken(String tokenValue) {
         return tokens.size() > 0 && tokens.contains(tokenValue.toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Looks through the list of tokens for the specified string and finds the index. - not case-sensitive. The string
+     * has to be a single token.
+     *
+     * @param tokenValue - The string token, to look for. Not case-sensitive. Has to be a single token.
+     *
+     * @return (int) index of the string. If the string is not found, -1 is returned.
+     */
+    public int getTokenIndexOf(String tokenValue) {
+        for (int i = 0; i < tokens.size(); i++){
+            if (tokens.get(i).equals(tokenValue.toUpperCase(Locale.ROOT)))
+                return i;
+        }
+        return -1;
     }
 }

--- a/src/test/cobol/MOCKTEST/MockCallTest
+++ b/src/test/cobol/MOCKTEST/MockCallTest
@@ -1,0 +1,66 @@
+           TestSuite "Mock Call statements test"
+
+           MOCK CALL 'PROG1'
+                MOVE "Global PROG1" TO VALUE-1
+           END-MOCK
+
+           TestCase "Simple call mock works"
+           MOCK CALL 'PROG1'
+                MOVE "From mocked PROG1" TO VALUE-1
+           END-MOCK
+           PERFORM 600-MAKE-CALL
+           EXPECT VALUE-1 TO BE "From mocked PROG1"
+           EXPECT VALUE-2 TO BE "arg2"
+
+           TestCase "Simple global call mock works"
+           PERFORM 600-MAKE-CALL
+           EXPECT VALUE-1 TO BE "Global PROG1"
+           EXPECT VALUE-2 TO BE "arg2"
+
+           TestCase "Call mock with argument works"
+           MOCK CALL VALUE-2 USING VALUE-1
+                MOVE "From mocked PROG2" TO VALUE-1
+           END-MOCK
+           PERFORM 700-MAKE-CALL
+           EXPECT VALUE-1 TO BE "From mocked PROG2"
+           EXPECT VALUE-2 TO BE "arg2"
+
+           TestCase "Call mock with content reference for arguments work"
+           MOCK CALL 'PROG3' USING
+             BY CONTENT VALUE-1,
+             BY VALUE VALUE-2,
+             VALUE-3
+                MOVE "content" TO VALUE-1
+                MOVE "value" TO VALUE-2
+                MOVE "reference" TO VALUE-3
+           END-MOCK
+           PERFORM 800-MAKE-CALL
+           EXPECT VALUE-1 TO BE "content"
+           EXPECT VALUE-2 TO BE "value"
+           EXPECT VALUE-3 TO BE "reference"
+
+           TestCase "Paragraph mock is called and call mock is ignored"
+           MOCK CALL 'PROG3' USING
+             BY CONTENT VALUE-1,
+             BY VALUE VALUE-2,
+             VALUE-3
+                MOVE "content" TO VALUE-1
+                MOVE "value" TO VALUE-2
+                MOVE "reference" TO VALUE-3
+           END-MOCK
+           MOCK PARAGRAPH 800-MAKE-CALL
+             MOVE "overwritten" TO VALUE-1
+           END-MOCK
+           MOVE "arg2" TO VALUE-2
+           MOVE "arg3" TO VALUE-3
+           PERFORM 800-MAKE-CALL
+           EXPECT VALUE-1 TO BE "overwritten"
+           EXPECT VALUE-2 TO BE "arg2"
+           EXPECT VALUE-3 TO BE "arg3"
+
+           TestCase "Global call mock is not overwritten by local call mock (Should fail)"
+           MOCK CALL 'PROG1'
+                MOVE "Local PROG1" TO VALUE-1
+           END-MOCK
+           PERFORM 600-MAKE-CALL
+           EXPECT VALUE-1 TO BE "Global PROG1"

--- a/src/test/cobol/MOCKTEST/MockCallTest
+++ b/src/test/cobol/MOCKTEST/MockCallTest
@@ -11,11 +11,13 @@
            PERFORM 600-MAKE-CALL
            EXPECT VALUE-1 TO BE "From mocked PROG1"
            EXPECT VALUE-2 TO BE "arg2"
+           VERIFY CALL 'PROG1' HAPPENED ONCE
 
            TestCase "Simple global call mock works"
            PERFORM 600-MAKE-CALL
            EXPECT VALUE-1 TO BE "Global PROG1"
            EXPECT VALUE-2 TO BE "arg2"
+           VERIFY CALL 'PROG1' HAPPENED ONCE
 
            TestCase "Call mock with argument works"
            MOCK CALL VALUE-2 USING VALUE-1
@@ -24,6 +26,8 @@
            PERFORM 700-MAKE-CALL
            EXPECT VALUE-1 TO BE "From mocked PROG2"
            EXPECT VALUE-2 TO BE "arg2"
+           VERIFY CALL VALUE-2 USING VALUE-1
+                HAPPENED ONCE
 
            TestCase "Call mock with content reference for arguments work"
            MOCK CALL 'PROG3' USING
@@ -38,6 +42,11 @@
            EXPECT VALUE-1 TO BE "content"
            EXPECT VALUE-2 TO BE "value"
            EXPECT VALUE-3 TO BE "reference"
+           VERIFY CALL 'PROG3' USING
+                BY CONTENT VALUE-1,
+                BY VALUE VALUE-2,
+                VALUE-3
+                HAPPENED 2 TIMES
 
            TestCase "Paragraph mock is called and call mock is ignored"
            MOCK CALL 'PROG3' USING
@@ -57,6 +66,12 @@
            EXPECT VALUE-1 TO BE "overwritten"
            EXPECT VALUE-2 TO BE "arg2"
            EXPECT VALUE-3 TO BE "arg3"
+           VERIFY PARAGRAPH 800-MAKE-CALL HAPPENED ONCE
+           VERIFY CALL 'PROG3' USING
+                BY CONTENT VALUE-1,
+                BY VALUE VALUE-2,
+                VALUE-3
+                NEVER HAPPENED
 
            TestCase "Global call mock is not overwritten by local call mock (Should fail)"
            MOCK CALL 'PROG1'

--- a/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest
+++ b/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest
@@ -1,4 +1,4 @@
-           TestSuite "Mocking tests"
+           TestSuite "Mock Sections And Paragraphs"
 
            MOCK SECTION 000-START
            PERFORM 100-WELCOME
@@ -31,7 +31,7 @@
            Expect VALUE-2 to be "a mock"
            VERIFY SECTION 000-START HAPPENED AT LEAST 2 TIMES
 
-           TestCase "Multiple local mocks behaves as intended"
+           TestCase "Multiple local mocks behaves as intended (First Verify should fail)"
            MOCK SECTION 000-START
                 MOVE "This is" TO VALUE-1
                 MOVE "a mock" TO VALUE-2

--- a/src/test/java/com/neopragma/cobolcheck/InterpreterControllerTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/InterpreterControllerTest.java
@@ -172,6 +172,76 @@ public class InterpreterControllerTest {
     }
 
     @Test
+    public void it_sets_possible_mock_identifier_to_call_program_name() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "           CALL 'PROG1'";
+        String actual = "";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, null);
+
+        while (interpreterController.interpretNextLine() != null){
+            interpreterController.interpretNextLine();
+            actual = interpreterController.getPossibleMockIdentifier();
+        }
+
+        assertEquals("'PROG1'", actual);
+    }
+
+    @Test
+    public void it_sets_possible_mock_args() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "           CALL 'PROG1' USING VALUE-1";
+        List<String> actual = new ArrayList<>();
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, null);
+
+        while (interpreterController.interpretNextLine() != null){
+            interpreterController.interpretNextLine();
+            actual = interpreterController.getPossibleMockArgs();
+        }
+
+        assertEquals("REFERENCE VALUE-1", actual.get(0));
+    }
+
+    @Test
+    public void it_sets_possible_mock_args_with_content_reference() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "           CALL 'PROG3' USING  BY CONTENT VALUE-1, BY REFERENCE VALUE-2";
+        List<String> actual = new ArrayList<>();
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, null);
+
+        while (interpreterController.interpretNextLine() != null){
+            interpreterController.interpretNextLine();
+            actual = interpreterController.getPossibleMockArgs();
+        }
+
+        assertEquals("CONTENT VALUE-1", actual.get(0));
+        assertEquals("REFERENCE VALUE-2", actual.get(1));
+    }
+
+    @Test
+    public void it_sets_possible_mock_args_with_content_reference_multiline() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "           CALL 'PROG3' USING";
+        String str3 = "             BY CONTENT VALUE-1,";
+        String str4 = "             BY VALUE VALUE-2,";
+        String str5 = "             VALUE-3";
+        List<String> actual = new ArrayList<>();
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
+
+        while (interpreterController.interpretNextLine() != null){
+            interpreterController.interpretNextLine();
+            actual = interpreterController.getPossibleMockArgs();
+        }
+
+        assertEquals("CONTENT VALUE-1", actual.get(0));
+        assertEquals("VALUE VALUE-2", actual.get(1));
+        assertEquals("REFERENCE VALUE-3", actual.get(2));
+    }
+
+    @Test
     public void it_ignores_lines_that_does_not_change_flags() throws IOException {
 
         boolean hasLine1Changed = false;

--- a/src/test/java/com/neopragma/cobolcheck/InterpreterTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/InterpreterTest.java
@@ -1,8 +1,9 @@
 package com.neopragma.cobolcheck;
 
-import com.neopragma.cobolcheck.exceptions.PossibleInternalLogicErrorException;
 import com.neopragma.cobolcheck.features.interpreter.*;
 import com.neopragma.cobolcheck.services.Constants;
+import com.neopragma.cobolcheck.services.cobolLogic.CobolLine;
+import com.neopragma.cobolcheck.services.cobolLogic.Interpreter;
 import com.neopragma.cobolcheck.services.cobolLogic.TokenExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/neopragma/cobolcheck/MockIT.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockIT.java
@@ -153,6 +153,56 @@ public class MockIT {
         assertEquals(getTrimmedList(expected3), actual);
     }
 
+    @Test
+    public void it_inserts_call_mocks_correctly() throws IOException {
+        String s1 = "       WORKING-STORAGE SECTION.";
+        String s2 = "       PROCEDURE DIVISION.";
+        String s3 = "       000-START SECTION.";
+        String s4 = "           MOVE \"Value1\" to VALUE-1";
+        String s5 = "           EXIT SECTION.";
+        String s6 = "       100-WELCOME SECTION.";
+        String s7 = "           CALL 'prog1' USING";
+        String s8 = "               BY CONTENT VALUE-1, VALUE-2.";
+        String s9 = "           MOVE \"Hello\" to VALUE-1.";
+        String s10 = "       200-GOODBYE SECTION.";
+        String s11 = "          MOVE \"Bye\" to VALUE-1";
+        String s12 = "          CALL 'prog2' USING VALUE-1";
+        String s13 = "          CALL 'prog2' USING VALUE-1.";
+        String s14 = "          .";
+
+        String t1 = "           TestSuite \"Mocking tests\"";
+        String t2 = "           MOCK SECTION 100-WELCOME";
+        String t3 = "               MOVE \"mock\" TO VALUE-1";
+        String t4 = "           END-MOCK";
+        String t5 = "           MOCK CALL 'prog2' USING VALUE-1";
+        String t6 = "               MOVE \"prog2\" TO VALUE-1";
+        String t7 = "           END-MOCK";
+        String t8 = "           TestCase \"Local mock overwrites global mock\"";
+        String t9 = "           MOCK SECTION 200-GOODBYE";
+        String t10 = "                MOVE \"Goodbye\" TO VALUE-1";
+        String t11 = "           END-MOCK";
+        String t12 = "           PERFORM 200-GOODBYE";
+        String t13 = "           Expect VALUE-1 to be \"Goodbye\"";
+        String t14 = "           TestCase \"Simply a test\"";
+        String t15 = "           MOCK SECTION 000-START";
+        String t16 = "           END-MOCK";
+        String t17 = "           MOCK CALL 'prog1' USING BY CONTENT VALUE-1, VALUE-2";
+        String t18 = "           END-MOCK";
+        String t19 = "           MOCK SECTION 200-GOODBYE";
+        String t20 = "           END-MOCK";
+
+        Mockito.when(mockedInterpreterReader.readLine()).thenReturn(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10,
+                s11, s12, s13, s14, null);
+        Mockito.when(mockedParserReader.readLine()).thenReturn(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11,
+                t12, t13, t14, t15, t16, t17, t18, t19, t20, null);
+
+        generator = new Generator(interpreterController, writerController, testSuiteParserController);
+
+        List<String> actual = getTrimmedList(removeBoilerPlateCode(writer.toString(), boilerPlateTags));
+
+        assertEquals(getTrimmedList(expected4), actual);
+    }
+
     private List<String> getTrimmedList(String text){
         String[] lines = text.split(Constants.NEWLINE);
         List<String> result = new ArrayList<>();
@@ -404,6 +454,175 @@ public class MockIT {
                     "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
                     "           EXIT SECTION                                                         " + Constants.NEWLINE +
                     "           .                                                                   " + Constants.NEWLINE;
+
+    private String expected4 =
+            "       WORKING-STORAGE SECTION.                                                 " +     Constants.NEWLINE +
+            "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"SECTION 100-WELCOME\".                                 " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"CALL 'prog2'\".                                        " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"CALL 'prog1'\".                                        " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
+            "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
+            "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
+            "           PERFORM UT-INITIALIZE                                                " + Constants.NEWLINE +
+            "           DISPLAY \"TESTSUITE:\"                                                 " + Constants.NEWLINE +
+            "           DISPLAY \"Mocking tests\"                                              " + Constants.NEWLINE +
+            "           MOVE \"Mocking tests\"                                                 " + Constants.NEWLINE +
+            "               TO UT-TEST-SUITE-NAME                                            " + Constants.NEWLINE +
+            "           MOVE \"Local mock overwrites global mock\"                             " + Constants.NEWLINE +
+            "               TO UT-TEST-CASE-NAME                                             " + Constants.NEWLINE +
+            "           PERFORM UT-BEFORE                                                    " + Constants.NEWLINE +
+            "           PERFORM UT-INITIALIZE-MOCK-COUNT                                     " + Constants.NEWLINE +
+            "            PERFORM 200-GOODBYE                                                 " + Constants.NEWLINE +
+            "           ADD 1 TO UT-TEST-CASE-COUNT                                          " + Constants.NEWLINE +
+            "           SET UT-NORMAL-COMPARE TO TRUE                                        " + Constants.NEWLINE +
+            "           SET UT-ALPHANUMERIC-COMPARE TO TRUE                                  " + Constants.NEWLINE +
+            "           MOVE VALUE-1 TO UT-ACTUAL                                            " + Constants.NEWLINE +
+            "           MOVE \"Goodbye\"                                                       " + Constants.NEWLINE +
+            "               TO UT-EXPECTED                                                   " + Constants.NEWLINE +
+            "           SET UT-RELATION-EQ TO TRUE                                           " + Constants.NEWLINE +
+            "           PERFORM UT-CHECK-EXPECTATION                                         " + Constants.NEWLINE +
+            "           PERFORM UT-AFTER                                                     " + Constants.NEWLINE +
+            "           MOVE \"Simply a test\"                                                 " + Constants.NEWLINE +
+            "               TO UT-TEST-CASE-NAME                                             " + Constants.NEWLINE +
+            "           PERFORM UT-BEFORE                                                    " + Constants.NEWLINE +
+            "           PERFORM UT-INITIALIZE-MOCK-COUNT                                     " + Constants.NEWLINE +
+            "       UT-INITIALIZE-MOCK-COUNT.                                                " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Sets all global mock counters and expected count to 0                    " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           MOVE 0 TO UT-1-0-1-MOCK-COUNT                                        " + Constants.NEWLINE +
+            "           MOVE 0 TO UT-1-0-1-MOCK-EXPECTED                                     " + Constants.NEWLINE +
+            "           MOVE 0 TO UT-1-0-2-MOCK-COUNT                                        " + Constants.NEWLINE +
+            "           MOVE 0 TO UT-1-0-2-MOCK-EXPECTED                                     " + Constants.NEWLINE +
+            "           .                                                                    " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Paragraphs called when mocking                                           " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "       1-0-1-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Global mock of: SECTION: 100-WELCOME                                     " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-0-1-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "               MOVE \"mock\" TO VALUE-1                                           " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       1-0-2-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Global mock of: CALL: 'prog2'                                            " + Constants.NEWLINE +
+            "      *With args: REFERENCE VALUE-1                                             " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-0-2-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "               MOVE \"prog2\" TO VALUE-1                                          " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       1-1-1-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Local mock of: SECTION: 200-GOODBYE                                      " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *In testcase: \"Local mock overwrites global mock\"                         " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-1-1-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "                MOVE \"Goodbye\" TO VALUE-1                                       " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       1-2-1-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Local mock of: SECTION: 000-START                                        " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *In testcase: \"Simply a test\"                                             " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-2-1-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       1-2-2-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Local mock of: CALL: 'prog1'                                             " + Constants.NEWLINE +
+            "      *With args: CONTENT VALUE-1, REFERENCE VALUE-2                            " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *In testcase: \"Simply a test\"                                             " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-2-2-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       1-2-3-MOCK.                                                              " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "      *Local mock of: SECTION: 200-GOODBYE                                      " + Constants.NEWLINE +
+            "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "      *In testcase: \"Simply a test\"                                             " + Constants.NEWLINE +
+            "      *****************************************************************         " + Constants.NEWLINE +
+            "           ADD 1 TO UT-1-2-3-MOCK-COUNT                                         " + Constants.NEWLINE +
+            "       .                                                                        " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
+            "       000-START SECTION.                                                       " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO \"Simply a test\"                                            " + Constants.NEWLINE +
+            "                    PERFORM 1-2-1-MOCK                                          " + Constants.NEWLINE +
+            "           WHEN OTHER                                                           " + Constants.NEWLINE +
+            "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "           EXIT SECTION.                                                        " + Constants.NEWLINE +
+            "       100-WELCOME SECTION.                                                     " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO ANY                                                        " + Constants.NEWLINE +
+            "                    PERFORM 1-0-1-MOCK                                          " + Constants.NEWLINE +
+            "           WHEN OTHER                                                           " + Constants.NEWLINE +
+            "      *    CALL 'prog1' USING BY CONTENT VALUE-1, VALUE-2.                      " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO \"Simply a test\"                                            " + Constants.NEWLINE +
+            "                    PERFORM 1-2-2-MOCK                                          " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "           MOVE \"Hello\" to VALUE-1                                              " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "           .                                                                    " + Constants.NEWLINE +
+            "       200-GOODBYE SECTION.                                                     " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO \"Local mock overwrites global mock\"                        " + Constants.NEWLINE +
+            "                    PERFORM 1-1-1-MOCK                                          " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO \"Simply a test\"                                            " + Constants.NEWLINE +
+            "                    PERFORM 1-2-3-MOCK                                          " + Constants.NEWLINE +
+            "           WHEN OTHER                                                           " + Constants.NEWLINE +
+            "          MOVE \"Bye\" to VALUE-1                                                 " + Constants.NEWLINE +
+            "      *   CALL 'prog2' USING VALUE-1                                            " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO ANY                                                        " + Constants.NEWLINE +
+            "                    PERFORM 1-0-2-MOCK                                          " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "      *   CALL 'prog2' USING VALUE-1.                                           " + Constants.NEWLINE +
+            "            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME                  " + Constants.NEWLINE +
+            "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
+            "                ALSO ANY                                                        " + Constants.NEWLINE +
+            "                    PERFORM 1-0-2-MOCK                                          " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "          .                                                                    ";
 
 }
 

--- a/src/test/java/com/neopragma/cobolcheck/MockingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockingTest.java
@@ -54,6 +54,12 @@ public class MockingTest {
         numericFields = new NumericFields();
     }
 
+    /********* TEST: *****************
+    *   Call exceptions
+    *   END-MOCK on same line
+    *   Call recognition
+     *******************************/
+
     @Test
     public void it_creates_a_new_section_mock() throws IOException {
         String str1 = "       TESTSUITE \"Name of test suite\"";
@@ -82,6 +88,36 @@ public class MockingTest {
 
         testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals("000-START", mockRepository.getMocks().get(0).getIdentifier());
+    }
+
+    @Test
+    public void call_mock_gets_correct_identifier() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1'";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals("'prog1'", mockRepository.getMocks().get(0).getIdentifier());
+    }
+
+    @Test
+    public void call_mock_gets_correct_identifier_when_variable() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL VALUE-1";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals("VALUE-1", mockRepository.getMocks().get(0).getIdentifier());
     }
 
     @Test
@@ -150,6 +186,21 @@ public class MockingTest {
     }
 
     @Test
+    public void call_mock_gets_call_type() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK call 'prog1'";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals("CALL", mockRepository.getMocks().get(0).getType());
+    }
+
+    @Test
     public void mock_gets_correct_lines() throws IOException {
         String str1 = "       TESTSUITE \"Name of test suite\"";
         String str2 = "       TESTCASE \"Name of test case\"";
@@ -166,6 +217,70 @@ public class MockingTest {
 
         testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
         assertEquals(expected, mockRepository.getMocks().get(0).getLines());
+    }
+
+    @Test
+    public void call_mock_gets_correct_lines() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1'";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add(str4);
+        expected.add(str5);
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals(expected, mockRepository.getMocks().get(0).getLines());
+    }
+
+    @Test
+    public void call_mock_gets_correct_lines_with_args() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1' USING VALUE-1";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add(str4);
+        expected.add(str5);
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals(expected, mockRepository.getMocks().get(0).getLines());
+    }
+
+    @Test
+    public void call_mock_gets_correct_arguments() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1' USING BY CONTENT VALUE-1,";
+        String str4 = "             BY REFERENCE VALUE-2,";
+        String str5 = "             BY VALUE VALUE-3,";
+        String str6 = "             VALUE-4, BY CONTENT VALUE-5";
+        String str7 = "          MOVE \"something\" TO this";
+        String str8 = "          MOVE \"something else\" TO other";
+        String str9 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("CONTENT VALUE-1");
+        expected.add("REFERENCE VALUE-2");
+        expected.add("VALUE VALUE-3");
+        expected.add("REFERENCE VALUE-4");
+        expected.add("CONTENT VALUE-5");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, str7, str8,
+                str9, null);
+
+        testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
+        assertEquals(expected, mockRepository.getMocks().get(0).getArguments());
     }
 
     @Test
@@ -298,6 +413,77 @@ public class MockingTest {
     }
 
     @Test
+    public void single_mock_call_gets_generated_correctly_with_comment() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1'";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("      *****************************************************************");
+        expected.add("      *Paragraphs called when mocking");
+        expected.add("      *****************************************************************");
+        expected.add("       1-1-1-MOCK.");
+        expected.add("      *****************************************************************");
+        expected.add("      *Local mock of: CALL: 'prog1'");
+        expected.add("      *In testsuite: \"Name of test suite\"");
+        expected.add("      *In testcase: \"Name of test case\"");
+        expected.add("      *****************************************************************");
+        expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
+        expected.add(str4);
+        expected.add(str5);
+        expected.add("       .");
+        expected.add("");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
+
+        List<String> actual = testSuiteParserController.generateMockSections(true);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void single_mock_call_with_args_gets_generated_correctly_with_comment() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1' USING BY CONTENT V-1, V-2";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("      *****************************************************************");
+        expected.add("      *Paragraphs called when mocking");
+        expected.add("      *****************************************************************");
+        expected.add("       1-1-1-MOCK.");
+        expected.add("      *****************************************************************");
+        expected.add("      *Local mock of: CALL: 'prog1'");
+        expected.add("      *With args: CONTENT V-1, REFERENCE V-2");
+        expected.add("      *In testsuite: \"Name of test suite\"");
+        expected.add("      *In testcase: \"Name of test case\"");
+        expected.add("      *****************************************************************");
+        expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
+        expected.add(str4);
+        expected.add(str5);
+        expected.add("       .");
+        expected.add("");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
+
+        List<String> actual = testSuiteParserController.generateMockSections(true);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void multiple_mock_sections_gets_generated_correctly() throws IOException {
         String str1 = "       TESTSUITE \"Name of test suite\"";
         String str2 = "       TESTCASE \"Name of test case\"";
@@ -398,7 +584,8 @@ public class MockingTest {
         testSuiteParserController.parseTestSuites(numericFields);
         testSuiteParserController.getProcedureDivisionTestCode();
 
-        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START", Constants.SECTION_TOKEN);
+        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START",
+                Constants.SECTION_TOKEN, new ArrayList<>());
 
         assertEquals(expected, actual);
     }
@@ -424,7 +611,35 @@ public class MockingTest {
         testSuiteParserController.parseTestSuites(numericFields);
         testSuiteParserController.getProcedureDivisionTestCode();
 
-        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START", Constants.SECTION_TOKEN);
+        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START",
+                Constants.SECTION_TOKEN, new ArrayList<>());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void single_local_mock_call_perform_evaluate_is_generated_correctly() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1' USING VALUE-1";
+        String str4 = "          MOVE \"something\" TO this";
+        String str5 = "          MOVE \"something else\" TO other";
+        String str6 = "       END-MOCK";
+
+        List<String> expected = new ArrayList<>();
+        expected.add("            EVALUATE UT-TEST-SUITE-NAME ALSO UT-TEST-CASE-NAME");
+        expected.add("                WHEN \"Name of test suite\"");
+        expected.add("                ALSO \"Name of test case\"");
+        expected.add("                    PERFORM 1-1-1-MOCK");
+        expected.add("            END-EVALUATE");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
+
+        testSuiteParserController.parseTestSuites(numericFields);
+        testSuiteParserController.getProcedureDivisionTestCode();
+
+        List<String> actual = testSuiteParserController.generateMockPerformCalls("'prog1'",
+                Constants.CALL_TOKEN, Arrays.asList("REFERENCE VALUE-1"));
 
         assertEquals(expected, actual);
     }
@@ -487,12 +702,16 @@ public class MockingTest {
         testSuiteParserController.parseTestSuites(numericFields);
         testSuiteParserController.getProcedureDivisionTestCode();
 
-        List<String> actual1 = testSuiteParserController.generateMockPerformCalls("000-START", Constants.SECTION_TOKEN);
-        List<String> actual2 = testSuiteParserController.generateMockPerformCalls("100-START", Constants.SECTION_TOKEN);
+        List<String> actual1 = testSuiteParserController.generateMockPerformCalls("000-START",
+                Constants.SECTION_TOKEN, new ArrayList<>());
+        List<String> actual2 = testSuiteParserController.generateMockPerformCalls("100-START",
+                Constants.SECTION_TOKEN, new ArrayList<>());
 
         assertEquals(expected1, actual1);
         assertEquals(expected2, actual2);
     }
+
+
 
     @Test
     public void no_evaluate_perform_is_generated_when_no_mock_present() throws IOException {
@@ -505,7 +724,8 @@ public class MockingTest {
         testSuiteParserController.parseTestSuites(numericFields);
         testSuiteParserController.getProcedureDivisionTestCode();
 
-        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START", Constants.SECTION_TOKEN);
+        List<String> actual = testSuiteParserController.generateMockPerformCalls("000-START",
+                Constants.SECTION_TOKEN, new ArrayList<>());
 
         assertTrue(actual.isEmpty());
     }
@@ -663,6 +883,30 @@ public class MockingTest {
 
         String expectedMessage = "Mock for 000-START in testsuite: \"Name of test suite\", testcase: " +
                 "\"Name of test case\" already exists in this Local testcase scope.";
+
+        Throwable ex = assertThrows(ComponentMockedTwiceInSameScopeException.class,
+                () -> testSuiteParserController.parseTestSuites(numericFields));
+        assertEquals(expectedMessage, ex.getMessage());
+    }
+
+    @Test
+    public void it_throws_when_identical_call_mocks_are_in_same_local_scope() throws IOException {
+        String str1 = "       TESTSUITE \"Name of test suite\"";
+        String str2 = "       TESTCASE \"Name of test case\"";
+        String str3 = "       MOCK CALL 'prog1' USING V1, V2";
+        String str4 = "          MOVE \"global\" TO this";
+        String str5 = "          MOVE \"mock\" TO other";
+        String str6 = "       END-MOCK";
+        String str7 = "       MOCK CALL 'prog1' USING V1, V2";
+        String str8 = "          MOVE \"global\" TO this";
+        String str9 = "          MOVE \"mock\" TO other";
+        String str10 = "       END-MOCK";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6,
+                str7, str8, str9, str10, null);
+
+        String expectedMessage = "Mock for 'prog1' in testsuite: \"Name of test suite\", testcase: " +
+                "\"Name of test case\" already exists with the given arguments in this Local testcase scope.";
 
         Throwable ex = assertThrows(ComponentMockedTwiceInSameScopeException.class,
                 () -> testSuiteParserController.parseTestSuites(numericFields));

--- a/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
@@ -352,6 +352,62 @@ public class TestSuiteParserParsingTest {
     }
 
     @Test
+    public void verify_can_attach_to_call_mock_with_no_arguments() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK CALL 'PROG1'");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append("       END-MOCK");
+        testSuite.append("       PERFORM 000-START");
+        testSuite.append("       VERIFY CALL 'PROG1' HAPPENED ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void verify_can_attach_to_call_mock_with_arguments() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       MOCK CALL 'PROG1' USING this, BY CONTENT other");
+        testSuite.append("          MOVE \"something\" TO this");
+        testSuite.append("          MOVE \"something else\" TO other");
+        testSuite.append("       END-MOCK");
+        testSuite.append("       PERFORM 000-START");
+        testSuite.append("       VERIFY CALL 'PROG1' USING");
+        testSuite.append("             this, BY CONTENT other");
+        testSuite.append("             HAPPENED ONCE");
+
+        List<String> expectedResult = new ArrayList<>();
+        expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES");
+        expectedResult.add("           MOVE UT-1-1-1-MOCK-NAME TO UT-MOCK-OPERATION");
+        expectedResult.add("           SET UT-VERIFY-EXACT TO TRUE");
+        expectedResult.add("           ADD 1 TO UT-TEST-CASE-COUNT");
+        expectedResult.add("           PERFORM UT-ASSERT-ACCESSES");
+        testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        List<String> actualResult = new ArrayList<>();
+        testSuiteParser.handleEndOfVerifyStatement(actualResult);
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
     public void it_throws_if_the_mock_that_verify_references_does_not_exist() {
         testSuite.append("       TESTSUITE \"Name of test suite\"");
         testSuite.append("       TESTCASE \"Name of test case\"");


### PR DESCRIPTION
### New Features:
- Mocking of Call statements is now possible
- Verifying Call statements is now possible

### Bug Fixes
- Fixed bug, where the end of a SECTION/PARAGRAPH would be found prematurely, when inserting "END-EVALUATE" to end the generated mock EVALUATE.
- Fixed bug where the testsuiteparser would write unwanted statements to the generated code.