### PR TITLE
Test prefix fix

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -9,6 +9,7 @@ config.loaded = production
 # Prefix for field names and paragraph names in the test management code that cobol-check
 # inserts into programs to be tested. The default is "UT-". If this conflicts with names
 # in the programs to be tested, you can override it with a value you specify here.
+# The value must be 3 characters or less. Cannot be empty.
 #---------------------------------------------------------------------------------------------------------------------
 cobolcheck.prefix = UT-
 

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/Mock.java
@@ -1,5 +1,7 @@
 package com.neopragma.cobolcheck.features.testSuiteParser;
 
+import com.neopragma.cobolcheck.services.Config;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,20 +28,24 @@ public class Mock {
         arguments = new ArrayList<>();
     }
 
-    public String getGeneratedMockIdentifier(){
+    public String getGeneratedMockIdentifierRoot(){
         return testSuiteNumber + "-" + testCaseNumber + "-" + mockNumber + "-MOCK";
     }
 
+    public String getGeneratedMockIdentifier(){
+        return Config.getTestCodePrefix() + getGeneratedMockIdentifierRoot();
+    }
+
     public String getGeneratedMockCountIdentifier(){
-        return "UT-" + getGeneratedMockIdentifier() + "-COUNT";
+        return Config.getTestCodePrefix() + getGeneratedMockIdentifierRoot() + "-COUNT";
     }
 
     public String getGeneratedMockCountExpectedIdentifier(){
-        return "UT-" + getGeneratedMockIdentifier() + "-EXPECTED";
+        return Config.getTestCodePrefix() + getGeneratedMockIdentifierRoot() + "-EXPECTED";
     }
 
     public String getGeneratedMockStringIdentifierName(){
-        return "UT-" + getGeneratedMockIdentifier() + "-NAME";
+        return Config.getTestCodePrefix() + getGeneratedMockIdentifierRoot() + "-NAME";
     }
 
     public String getMockDisplayString(){

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -14,6 +14,11 @@ public class MockGenerator {
     private final String performFormat = "                    PERFORM %s";
     private final String endEvaluateLine = "            END-EVALUATE";
 
+    private final String countMockInitialWSHeader = "       01 %sMOCKS-GENERATED.";
+    private final String initializeMockCountParagraphHeader = "       %sINITIALIZE-MOCK-COUNT.";
+
+
+
 
     /**Generates the lines for keeping track of mock counting
      * For each mock a variable are created for:
@@ -28,7 +33,7 @@ public class MockGenerator {
         if (mocks.isEmpty())
             return lines;
 
-        lines.add("       01  UT-MOCKS-GENERATED.");
+        lines.add(String.format(countMockInitialWSHeader, Config.getTestCodePrefix()));
         lines.addAll(generateMockCountValues(mocks));
 
         return lines;
@@ -41,7 +46,7 @@ public class MockGenerator {
      */
     List<String> generateMockCountInitializer(List<Mock> mocks){
         List<String> lines = new ArrayList<>();
-        lines.add("       UT-INITIALIZE-MOCK-COUNT.");
+        lines.add(String.format(initializeMockCountParagraphHeader, Config.getTestCodePrefix()));
         lines.addAll(CobolGenerator.generateCommentBlock("Sets all global mock counters and expected count to 0"));
 
         if (mocks.isEmpty()){

--- a/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/com/neopragma/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -14,7 +14,7 @@ public class MockGenerator {
     private final String performFormat = "                    PERFORM %s";
     private final String endEvaluateLine = "            END-EVALUATE";
 
-    private final String countMockInitialWSHeader = "       01 %sMOCKS-GENERATED.";
+    private final String countMockInitialWSHeader = "       01  %sMOCKS-GENERATED.";
     private final String initializeMockCountParagraphHeader = "       %sINITIALIZE-MOCK-COUNT.";
 
 

--- a/src/main/java/com/neopragma/cobolcheck/services/Config.java
+++ b/src/main/java/com/neopragma/cobolcheck/services/Config.java
@@ -96,8 +96,16 @@ public class Config {
 
     private static String testCodePrefix = "";
     public static String getTestCodePrefix() {
-        if (testCodePrefix.isEmpty())
+        if (testCodePrefix.isEmpty()){
             testCodePrefix = getString(Constants.COBOLCHECK_PREFIX_CONFIG_KEY, Constants.DEFAULT_COBOLCHECK_PREFIX);
+            if (testCodePrefix.length() > 3)
+                throw new PossibleInternalLogicErrorException("cobolcheck prefix defined in 'config.properties' must be 3 or less characters long. Given value: '"
+                    + testCodePrefix + "' is too long");
+            if (testCodePrefix.length() == 0)
+                throw new PossibleInternalLogicErrorException("cobolcheck prefix defined in 'config.properties' cannot be empty");
+
+        }
+
         return testCodePrefix;
     }
 

--- a/src/test/java/com/neopragma/cobolcheck/MockIT.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockIT.java
@@ -280,7 +280,7 @@ public class MockIT {
                     "      *****************************************************************         " + Constants.NEWLINE +
                     "      *Paragraphs called when mocking                                           " + Constants.NEWLINE +
                     "      *****************************************************************         " + Constants.NEWLINE +
-                    "       1-0-1-MOCK.                                                              " + Constants.NEWLINE +
+                    "       UT-1-0-1-MOCK.                                                              " + Constants.NEWLINE +
                     "      *****************************************************************         " + Constants.NEWLINE +
                     "      *Global mock of: SECTION: 000-START                                       " + Constants.NEWLINE +
                     "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -294,12 +294,12 @@ public class MockIT {
                     "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
                     "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
                     "                   ALSO ANY                                                     " + Constants.NEWLINE +
-                    "                    PERFORM 1-0-1-MOCK                                          " + Constants.NEWLINE +
+                    "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
                     "           WHEN OTHER                                                           " + Constants.NEWLINE +
                     "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
                     "            END-EVALUATE                                                        " + Constants.NEWLINE +
                     "           EXIT SECTION                                                         " + Constants.NEWLINE +
-                    "           .                                                                   " + Constants.NEWLINE;
+                    "           .                                                                   "  + Constants.NEWLINE;
 
     private String expected2 =
             "       WORKING-STORAGE SECTION.                                                 " +      Constants.NEWLINE  +
@@ -383,7 +383,7 @@ public class MockIT {
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Paragraphs called when mocking                                           " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
-            "       1-0-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-0-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Global mock of: SECTION: 000-START                                       " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -392,7 +392,7 @@ public class MockIT {
             "           PERFORM 100-WELCOME                                                  " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-1-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-1-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 000-START                                        " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -402,7 +402,7 @@ public class MockIT {
             "                MOVE \"This is\" TO VALUE-1                                       " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 000-START                                        " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -411,7 +411,7 @@ public class MockIT {
             "           ADD 1 TO UT-1-2-1-MOCK-COUNT                                         " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-2-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-2-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 100-WELCOME                                      " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -420,7 +420,7 @@ public class MockIT {
             "           ADD 1 TO UT-1-2-2-MOCK-COUNT                                         " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-3-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-3-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 200-GOODBYE                                      " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -434,13 +434,13 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Local mock overwrites global mock\"                     " + Constants.NEWLINE +
-            "                    PERFORM 1-1-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-1-1-MOCK                                          " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-1-MOCK                                          " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
-            "                    PERFORM 1-0-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
@@ -451,7 +451,7 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-2-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-2-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Hello\" to VALUE-1                                              " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
@@ -461,7 +461,7 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-3-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-3-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Bye\" to VALUE-1                                                " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
@@ -515,7 +515,7 @@ public class MockIT {
                     "       000-START SECTION.                                                       " + Constants.NEWLINE +
                     "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
                     "           EXIT SECTION                                                         " + Constants.NEWLINE +
-                    "           .                                                                   " + Constants.NEWLINE;
+                    "           .                                                                   ".replace(" UT-", " " + Config.getTestCodePrefix());
 
     private String expected4 =
             "       WORKING-STORAGE SECTION.                                                 " +     Constants.NEWLINE +
@@ -605,7 +605,7 @@ public class MockIT {
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Paragraphs called when mocking                                           " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
-            "       1-0-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-0-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Global mock of: SECTION: 100-WELCOME                                     " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -614,7 +614,7 @@ public class MockIT {
             "               MOVE \"mock\" TO VALUE-1                                           " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-0-2-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-0-2-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Global mock of: CALL: 'prog2'                                            " + Constants.NEWLINE +
             "      *With args: REFERENCE VALUE-1                                             " + Constants.NEWLINE +
@@ -624,7 +624,7 @@ public class MockIT {
             "               MOVE \"prog2\" TO VALUE-1                                          " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-1-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-1-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 200-GOODBYE                                      " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -634,7 +634,7 @@ public class MockIT {
             "                MOVE \"Goodbye\" TO VALUE-1                                       " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-1-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-1-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 000-START                                        " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -643,7 +643,7 @@ public class MockIT {
             "           ADD 1 TO UT-1-2-1-MOCK-COUNT                                         " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-2-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-2-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: CALL: 'prog1'                                             " + Constants.NEWLINE +
             "      *With args: CONTENT VALUE-1, REFERENCE VALUE-2                            " + Constants.NEWLINE +
@@ -653,7 +653,7 @@ public class MockIT {
             "           ADD 1 TO UT-1-2-2-MOCK-COUNT                                         " + Constants.NEWLINE +
             "       .                                                                        " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
-            "       1-2-3-MOCK.                                                              " + Constants.NEWLINE +
+            "       UT-1-2-3-MOCK.                                                              " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "      *Local mock of: SECTION: 200-GOODBYE                                      " + Constants.NEWLINE +
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -667,7 +667,7 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
@@ -677,14 +677,14 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
-            "                    PERFORM 1-0-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "      *    CALL 'prog1' USING BY CONTENT VALUE-1, VALUE-2.                      " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-2-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "           MOVE \"Hello\" to VALUE-1                                              " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
@@ -694,10 +694,10 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Local mock overwrites global mock\"                     " + Constants.NEWLINE +
-            "                    PERFORM 1-1-1-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-1-1-MOCK                                          " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
-            "                    PERFORM 1-2-3-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-2-3-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "          MOVE \"Bye\" to VALUE-1                                                 " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1                                            " + Constants.NEWLINE +
@@ -705,14 +705,14 @@ public class MockIT {
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
-            "                    PERFORM 1-0-2-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-0-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1.                                           " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
-            "                    PERFORM 1-0-2-MOCK                                          " + Constants.NEWLINE +
+            "                    PERFORM UT-1-0-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "          .                                                                    ";

--- a/src/test/java/com/neopragma/cobolcheck/MockingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/MockingTest.java
@@ -148,10 +148,10 @@ public class MockingTest {
                 str20, str21, null);
 
         testSuiteParser.getParsedTestSuiteLines(mockedReader, numericFields);
-        assertEquals("1-1-1-MOCK", mockRepository.getMocks().get(0).getGeneratedMockIdentifier());
-        assertEquals("1-1-2-MOCK", mockRepository.getMocks().get(1).getGeneratedMockIdentifier());
-        assertEquals("1-2-1-MOCK", mockRepository.getMocks().get(2).getGeneratedMockIdentifier());
-        assertEquals("2-1-1-MOCK", mockRepository.getMocks().get(3).getGeneratedMockIdentifier());
+        assertEquals("UT-1-1-1-MOCK", mockRepository.getMocks().get(0).getGeneratedMockIdentifier());
+        assertEquals("UT-1-1-2-MOCK", mockRepository.getMocks().get(1).getGeneratedMockIdentifier());
+        assertEquals("UT-1-2-1-MOCK", mockRepository.getMocks().get(2).getGeneratedMockIdentifier());
+        assertEquals("UT-2-1-1-MOCK", mockRepository.getMocks().get(3).getGeneratedMockIdentifier());
     }
 
     @Test
@@ -324,7 +324,7 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
         expected.add(str4);
         expected.add(str5);
@@ -354,7 +354,7 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("      *****************************************************************");
         expected.add("      *Local mock of: SECTION: 000-START");
         expected.add("      *In testsuite: \"Name of test suite\"");
@@ -389,7 +389,7 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("      *****************************************************************");
         expected.add("      *Local mock of: PARAGRAPH: 000-START");
         expected.add("      *In testsuite: \"Name of test suite\"");
@@ -424,7 +424,7 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("      *****************************************************************");
         expected.add("      *Local mock of: CALL: 'prog1'");
         expected.add("      *In testsuite: \"Name of test suite\"");
@@ -459,7 +459,7 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("      *****************************************************************");
         expected.add("      *Local mock of: CALL: 'prog1'");
         expected.add("      *With args: CONTENT V-1, REFERENCE V-2");
@@ -510,25 +510,25 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("      *Paragraphs called when mocking");
         expected.add("      *****************************************************************");
-        expected.add("       1-1-1-MOCK.");
+        expected.add("       UT-1-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
         expected.add(str4);
         expected.add(str5);
         expected.add("       .");
         expected.add("");
-        expected.add("       1-1-2-MOCK.");
+        expected.add("       UT-1-1-2-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-2-MOCK-COUNT");
         expected.add(str8);
         expected.add(str9);
         expected.add("       .");
         expected.add("");
-        expected.add("       1-2-1-MOCK.");
+        expected.add("       UT-1-2-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-2-1-MOCK-COUNT");
         expected.add(str13);
         expected.add(str14);
         expected.add("       .");
         expected.add("");
-        expected.add("       2-1-1-MOCK.");
+        expected.add("       UT-2-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-2-1-1-MOCK-COUNT");
         expected.add(str19);
         expected.add(str20);
@@ -576,7 +576,7 @@ public class MockingTest {
         expected.add("                   ALSO UT-TEST-CASE-NAME");
         expected.add("                WHEN \"Name of test suite\"");
         expected.add("                   ALSO ANY");
-        expected.add("                    PERFORM 1-0-1-MOCK");
+        expected.add("                    PERFORM UT-1-0-1-MOCK");
         expected.add("           WHEN OTHER");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
@@ -604,7 +604,7 @@ public class MockingTest {
         expected.add("                   ALSO UT-TEST-CASE-NAME");
         expected.add("                WHEN \"Name of test suite\"");
         expected.add("                   ALSO \"Name of test case\"");
-        expected.add("                    PERFORM 1-1-1-MOCK");
+        expected.add("                    PERFORM UT-1-1-1-MOCK");
         expected.add("           WHEN OTHER");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
@@ -632,7 +632,7 @@ public class MockingTest {
         expected.add("                   ALSO UT-TEST-CASE-NAME");
         expected.add("                WHEN \"Name of test suite\"");
         expected.add("                   ALSO \"Name of test case\"");
-        expected.add("                    PERFORM 1-1-1-MOCK");
+        expected.add("                    PERFORM UT-1-1-1-MOCK");
         expected.add("            END-EVALUATE");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
@@ -679,16 +679,16 @@ public class MockingTest {
         expected1.add("                   ALSO UT-TEST-CASE-NAME");
         expected1.add("                WHEN \"Name of test suite\"");
         expected1.add("                   ALSO \"Name of test case\"");
-        expected1.add("                    PERFORM 1-1-1-MOCK");
+        expected1.add("                    PERFORM UT-1-1-1-MOCK");
         expected1.add("                WHEN \"Name of test suite\"");
         expected1.add("                   ALSO \"test case 2\"");
-        expected1.add("                    PERFORM 1-2-1-MOCK");
+        expected1.add("                    PERFORM UT-1-2-1-MOCK");
         expected1.add("                WHEN \"Test suite 2\"");
         expected1.add("                   ALSO \"test case 1\"");
-        expected1.add("                    PERFORM 2-1-1-MOCK");
+        expected1.add("                    PERFORM UT-2-1-1-MOCK");
         expected1.add("                WHEN \"Name of test suite\"");
         expected1.add("                   ALSO ANY");
-        expected1.add("                    PERFORM 1-0-1-MOCK");
+        expected1.add("                    PERFORM UT-1-0-1-MOCK");
         expected1.add("           WHEN OTHER");
 
         List<String> expected2 = new ArrayList<>();
@@ -696,7 +696,7 @@ public class MockingTest {
         expected2.add("                   ALSO UT-TEST-CASE-NAME");
         expected2.add("                WHEN \"Name of test suite\"");
         expected2.add("                   ALSO \"Name of test case\"");
-        expected2.add("                    PERFORM 1-1-2-MOCK");
+        expected2.add("                    PERFORM UT-1-1-2-MOCK");
         expected2.add("           WHEN OTHER");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6,

--- a/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
+++ b/src/test/java/com/neopragma/cobolcheck/TestSuiteParserParsingTest.java
@@ -612,8 +612,4 @@ public class TestSuiteParserParsingTest {
         List<String> actualResult = testSuiteParserController.generateBeforeAfterBranchParagraphs(false);
         assertEquals(expectedResult, actualResult);
     }
-
-
-
-
 }


### PR DESCRIPTION
- Fixed cobol test code prefix for generated code
- Cobolcheck now throws an exception if the prefix given in config.properties is longer than 3 characters or if it is empty.