### PR TITLE
Remove copyright notice

### DIFF
--- a/notice.txt
+++ b/notice.txt
@@ -1,5 +1,3 @@
 /*
-Copyright 2020 David Nicolette
-
 SPDX-License-Identifier: Apache-2.0
 */


### PR DESCRIPTION
In agreement with Dave Nicolette, on the TSC meeting the 17/03-22, we are removing the copyright, as it is no longer valid.