### PR TITLE
A couple of small bug fixes

### DIFF
--- a/CC##99.CBL
+++ b/CC##99.CBL
@@ -70,9 +70,9 @@
            05  UT-TEST-CASE-NAME         PIC X(80)  VALUE SPACES.               
            05  UT-TEST-CASE-NUMBER       PIC ZZ9.                               
            05  UT-RETCODE                PIC 9(4)   VALUE ZERO.                 
-           05  UT-TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO.                 
-           05  UT-NUMBER-PASSED          PIC 9(4)   VALUE ZERO.                 
-           05  UT-NUMBER-FAILED          PIC 9(4)   VALUE ZERO.                 
+           05  UT-TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO COMP.            
+           05  UT-NUMBER-PASSED          PIC 9(4)   VALUE ZERO COMP.            
+           05  UT-NUMBER-FAILED          PIC 9(4)   VALUE ZERO COMP.            
            05  UT-EXPECTED-TRIM          PIC S9(5) COMP-3 VALUE ZERO.           
            05  UT-ACTUAL-TRIM            PIC S9(5) COMP-3 VALUE ZERO.           
        01  UT-MOCKS.                                                            
@@ -140,96 +140,96 @@
            05  TEMP              PIC X(80).                                     
                                                                                 
        01  UT-MOCKS-GENERATED.                                                  
-           05  UT-2-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-0-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-2-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-0-2-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
-           05  UT-2-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-2-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-2-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-2-2-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
-           05  UT-2-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-3-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-2-3-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-3-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-3-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-3-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-3-2-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
-           05  UT-2-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-4-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-2-4-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-2-4-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-2-4-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-2-4-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-2-4-2-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
-           05  UT-5-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-0-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL 'PROG1'".                                        
-           05  UT-5-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-1-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL 'PROG1'".                                        
-           05  UT-5-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-3-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL VALUE-2".                                        
-           05  UT-5-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-4-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL 'PROG3'".                                        
-           05  UT-5-5-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-5-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-5-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-5-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-5-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL 'PROG3'".                                        
-           05  UT-5-5-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-5-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-5-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-5-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-5-2-MOCK-NAME        PIC X(40)                              
                    VALUE "PARAGRAPH 800-MAKE-CALL".                             
-           05  UT-5-6-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-5-6-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-5-6-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-5-6-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-5-6-1-MOCK-NAME        PIC X(40)                              
                    VALUE "CALL 'PROG1'".                                        
-           05  UT-6-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-0-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-6-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-0-2-MOCK-NAME        PIC X(40)                              
                    VALUE "PARAGRAPH 300-CHANGE-1".                              
-           05  UT-6-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-2-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-6-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-3-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-3-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-3-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 000-START".                                   
-           05  UT-6-3-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-3-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-3-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-3-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-3-2-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
-           05  UT-6-3-3-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-3-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-3-3-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-3-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-3-3-MOCK-NAME        PIC X(40)                              
                    VALUE "PARAGRAPH 500-SWITCH".                                
-           05  UT-6-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-4-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-4-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-4-1-MOCK-NAME        PIC X(40)                              
                    VALUE "PARAGRAPH 500-SWITCH".                                
-           05  UT-6-5-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  
-           05  UT-6-5-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  
+           05  UT-6-5-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             
+           05  UT-6-5-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             
            05  UT-6-5-1-MOCK-NAME        PIC X(40)                              
                    VALUE "SECTION 100-WELCOME".                                 
        PROCEDURE DIVISION.                                                      

--- a/copybooks/CCHECKWS.CPY
+++ b/copybooks/CCHECKWS.CPY
@@ -51,9 +51,9 @@
            05  ==UT==TEST-CASE-NAME         PIC X(80)  VALUE SPACES.
            05  ==UT==TEST-CASE-NUMBER       PIC ZZ9.
            05  ==UT==RETCODE                PIC 9(4)   VALUE ZERO.
-           05  ==UT==TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO.
-           05  ==UT==NUMBER-PASSED          PIC 9(4)   VALUE ZERO.
-           05  ==UT==NUMBER-FAILED          PIC 9(4)   VALUE ZERO.
+           05  ==UT==TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO COMP.
+           05  ==UT==NUMBER-PASSED          PIC 9(4)   VALUE ZERO COMP.
+           05  ==UT==NUMBER-FAILED          PIC 9(4)   VALUE ZERO COMP.
            05  ==UT==EXPECTED-TRIM          PIC S9(5) COMP-3 VALUE ZERO.
            05  ==UT==ACTUAL-TRIM            PIC S9(5) COMP-3 VALUE ZERO.
        01  ==UT==MOCKS.

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -64,7 +64,8 @@ public class Keywords {
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
+                                Constants.ENDMOCK_KEYWORD),
                         KeywordAction.FIELDNAME));
         keywordInfo.put(Constants.NOT_KEYWORD,
                 new Keyword(Constants.NOT_KEYWORD,
@@ -169,7 +170,8 @@ public class Keywords {
                                 Constants.AFTER_EACH_TOKEN_HYPHEN,
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
-                                Constants.USING_TOKEN),
+                                Constants.USING_TOKEN,
+                                Constants.ENDMOCK_KEYWORD),
                         KeywordAction.FIELDNAME));
         keywordInfo.put(Constants.NUMERIC_LITERAL_KEYWORD,
                 new Keyword(Constants.NUMERIC_LITERAL_KEYWORD,
@@ -193,6 +195,7 @@ public class Keywords {
                                 Constants.TESTSUITE_KEYWORD,
                                 Constants.TESTCASE_KEYWORD,
                                 Constants.MOCK_KEYWORD,
+                                Constants.ENDMOCK_KEYWORD,
                                 Constants.VERIFY_KEYWORD,
                                 Constants.PARENTHESIS_ENCLOSED_KEYWORD),
                         KeywordAction.COBOL_STATEMENT));
@@ -242,6 +245,19 @@ public class Keywords {
         keywordInfo.put(Constants.MOCK_KEYWORD,
                 new Keyword(Constants.MOCK_KEYWORD,
                         Arrays.asList(Constants.MOCK_TYPE),
+                        KeywordAction.NONE));
+        keywordInfo.put(Constants.ENDMOCK_KEYWORD,
+                new Keyword(Constants.ENDMOCK_KEYWORD,
+                        Arrays.asList(Constants.COBOL_TOKEN,
+                                Constants.BEFORE_EACH_TOKEN,
+                                Constants.BEFORE_EACH_TOKEN_HYPHEN,
+                                Constants.AFTER_EACH_TOKEN,
+                                Constants.AFTER_EACH_TOKEN_HYPHEN,
+                                Constants.TESTSUITE_KEYWORD,
+                                Constants.TESTCASE_KEYWORD,
+                                Constants.MOCK_KEYWORD,
+                                Constants.VERIFY_KEYWORD,
+                                Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
 
         keywordInfo.put(Constants.MOCK_TYPE,

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -129,8 +129,8 @@ public class MockGenerator {
     private List<String> generateMockCountValues(List<Mock> mocks) {
         List<String> lines = new ArrayList<>();
         for (Mock mock : mocks){
-            lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO.");
-            lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(02) VALUE ZERO.");
+            lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO COMP.");
+            lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(02) VALUE ZERO COMP.");
             lines.add("           05  " + mock.getGeneratedMockStringIdentifierName() + "        PIC X(40)");
             lines.add("                   VALUE \"" + mock.getMockDisplayString() + "\".");
         }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -48,6 +48,8 @@ public class TestSuiteErrorLog {
 
     public String getLastErrorMessage(){ return lastErrorLogMessage; }
 
+    public String getLastKeywordValue() { return lastKeyword.value(); }
+
     public void checkExpectedTokenSyntax(Keyword currentKeyword, String currentFile, int lineNumber, int lineIndex){
         if (lastKeyword != null){
             String error = "";

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -238,8 +238,10 @@ public class TestSuiteParser {
                 testSuiteToken = testSuiteToken.toUpperCase(Locale.ROOT);
             }
 
-            if (Constants.IGNORED_TOKENS.contains(testSuiteToken))
+            if (Constants.IGNORED_TOKENS.contains(testSuiteToken)){
+                testSuiteToken = getNextTokenFromTestSuite(testSuiteReader);
                 continue;
+            }
 
             boolean cobolTokenIsFieldName = (expectInProgress || expectQualifiedName || expectMockIdentifier || (expectMockArguments && !expectUsing));
             Keyword keyword = Keywords.getKeywordFor(testSuiteToken, cobolTokenIsFieldName);

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -100,7 +100,7 @@ public final class Constants {
     public static final String BEFORE_EACH_TOKEN_HYPHEN = "BEFORE-EACH";
     public static final String AFTER_EACH_TOKEN_HYPHEN = "AFTER-EACH";
     public static final String PARA_TOKEN = "PARA";
-    public static final List<String> IGNORED_TOKENS = Arrays.asList("END-CALL");
+    public static final List<String> IGNORED_TOKENS = Arrays.asList("END-CALL", "END-MOCK");
 
     // Configuration key values
     public static final String CONCATENATED_TEST_SUITES_CONFIG_KEY = "concatenated.test.suites";

--- a/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKWS.CPY
+++ b/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKWS.CPY
@@ -61,9 +61,9 @@
            05  ==UT==TEST-CASE-NAME         PIC X(80)  VALUE SPACES.
            05  ==UT==TEST-CASE-NUMBER       PIC ZZ9.
            05  ==UT==RETCODE                PIC 9(4)   VALUE ZERO.
-           05  ==UT==TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO.
-           05  ==UT==NUMBER-PASSED          PIC 9(4)   VALUE ZERO.
-           05  ==UT==NUMBER-FAILED          PIC 9(4)   VALUE ZERO.
+           05  ==UT==TEST-CASE-COUNT        PIC 9(4)   VALUE ZERO COMP.
+           05  ==UT==NUMBER-PASSED          PIC 9(4)   VALUE ZERO COMP.
+           05  ==UT==NUMBER-FAILED          PIC 9(4)   VALUE ZERO COMP.
            05  ==UT==EXPECTED-TRIM          PIC S9(5) COMP-3 VALUE ZERO.
            05  ==UT==ACTUAL-TRIM            PIC S9(5) COMP-3 VALUE ZERO.
        01  ==UT==MOCKS.

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
@@ -53,7 +53,8 @@ public class KeywordsTest {
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
+                                Constants.ENDMOCK_KEYWORD),
                         KeywordAction.FIELDNAME),
                 Arguments.of(Constants.NOT_KEYWORD, Constants.NOT_KEYWORD,
                         Arrays.asList(Constants.TO_BE_KEYWORD,
@@ -136,7 +137,8 @@ public class KeywordsTest {
                 Constants.AFTER_EACH_TOKEN_HYPHEN,
                 Constants.HAPPENED_KEYWORD,
                 Constants.NEVER_HAPPENED_KEYWORD,
-                Constants.USING_TOKEN), keyword.getvalidNextKeys());
+                Constants.USING_TOKEN,
+                Constants.ENDMOCK_KEYWORD), keyword.getvalidNextKeys());
     }
 
     @Test
@@ -163,6 +165,7 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
+                Constants.ENDMOCK_KEYWORD,
                 Constants.VERIFY_KEYWORD,
                 Constants.PARENTHESIS_ENCLOSED_KEYWORD), keyword.getvalidNextKeys());
     }

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
@@ -246,8 +246,8 @@ public class MockIT {
     private String expected1 =
             "       WORKING-STORAGE SECTION.                                                 " + Constants.NEWLINE +
                     "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-                    "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-                    "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+                    "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+                    "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
                     "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
                     "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
                     "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
@@ -304,24 +304,24 @@ public class MockIT {
     private String expected2 =
             "       WORKING-STORAGE SECTION.                                                 " +      Constants.NEWLINE  +
             "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-1-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 100-WELCOME\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-3-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
             "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
@@ -520,28 +520,28 @@ public class MockIT {
     private String expected4 =
             "       WORKING-STORAGE SECTION.                                                 " +     Constants.NEWLINE +
             "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 100-WELCOME\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"CALL 'prog2'\".                                        " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-1-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"CALL 'prog1'\".                                        " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.                  " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-3-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
             "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
@@ -807,8 +807,8 @@ public class MockingTest {
 
         List<String> expected = new ArrayList<>();
         expected.add("       01  UT-MOCKS-GENERATED.");
-        expected.add("           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO.");
-        expected.add("           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO.");
+        expected.add("           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.");
+        expected.add("           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.");
         expected.add("           05  UT-1-1-1-MOCK-NAME        PIC X(40)");
         expected.add("                   VALUE \"SECTION 000-START\".");
 

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
@@ -71,7 +71,7 @@ public class TestSuiteErrorLogTest {
     }
 
     @Test
-    public void it_catches_unexpected_keyword_inside_block() {
+    public void it_catches_unexpected_keyword_inside_mock_block() {
         testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
         testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
         testSuite.append("       MOCK SECTION 000-START"+ Constants.NEWLINE);
@@ -82,6 +82,28 @@ public class TestSuiteErrorLogTest {
         expectedResult += "SYNTAX ERROR in file: null" + Constants.NEWLINE;
         expectedResult += "Unexpected token on line 4, index  8:" + Constants.NEWLINE;
         expectedResult += "Cannot have Cobol Check keyword <END-BEFORE> inside a MOCK block" + Constants.NEWLINE + Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_inside_before_each_block() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       BEFORE-EACH"+ Constants.NEWLINE);
+        testSuite.append("       VERIFY SECTION 000-START HAPPENED ONCE"+ Constants.NEWLINE);
+        testSuite.append("       END-BEFORE"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 4, index  8:" + Constants.NEWLINE;
+        expectedResult += "Cannot have Cobol Check keyword <VERIFY> inside a BEFORE EACH block" + Constants.NEWLINE + Constants.NEWLINE;
 
         assertThrows(TestSuiteSyntaxException.class, () -> {
             testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
@@ -156,6 +178,39 @@ public class TestSuiteErrorLogTest {
                     testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
                             numericFields);
                 });
+
+        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_detects_no_errros_with_mock_block_followed_by_before_each() {
+        testSuite.append("           TESTSUITE 'TEST'"+ Constants.NEWLINE);
+        testSuite.append("           MOCK SECTION INC-KALD-KISM567"+ Constants.NEWLINE);
+        testSuite.append("           DISPLAY 'INC-KALD-KISM567 MOCK'"+ Constants.NEWLINE);
+        testSuite.append("           SET STATU-OK IN RETURKODE-AREAL IN KISM567-PARM TO TRUE"+ Constants.NEWLINE);
+        testSuite.append("           END-MOCK"+ Constants.NEWLINE);
+        testSuite.append(""+ Constants.NEWLINE);
+        testSuite.append("           BEFORE-EACH"+ Constants.NEWLINE);
+        testSuite.append("           MOVE 0 TO BANKNR IN AARM503-PARM"+ Constants.NEWLINE);
+        testSuite.append("           END-BEFORE"+ Constants.NEWLINE);
+
+        String expectedResult = null;
+
+        testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
+
+        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_detects_no_errros_on_a_stub() {
+        testSuite.append("           TESTSUITE 'TEST'"+ Constants.NEWLINE);
+        testSuite.append("           MOCK SECTION 000-START END-MOCK"+ Constants.NEWLINE);
+
+        String expectedResult = null;
+
+        testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
 
         String actualResult = testSuiteErrorLog.getLastErrorMessage();
         assertEquals(expectedResult, actualResult);

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserParsingTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserParsingTest.java
@@ -3,6 +3,7 @@ package org.openmainframeproject.cobolcheck;
 import org.openmainframeproject.cobolcheck.exceptions.VerifyReferencesNonexistentMockException;
 import org.openmainframeproject.cobolcheck.features.testSuiteParser.*;
 import org.openmainframeproject.cobolcheck.features.writer.CobolWriter;
+import org.openmainframeproject.cobolcheck.services.Constants;
 import org.openmainframeproject.cobolcheck.services.cobolLogic.DataType;
 import org.openmainframeproject.cobolcheck.services.cobolLogic.NumericFields;
 import org.openmainframeproject.cobolcheck.services.Config;
@@ -382,14 +383,14 @@ public class TestSuiteParserParsingTest {
 
     @Test
     public void verify_can_attach_to_call_mock_with_no_arguments() {
-        testSuite.append("       TESTSUITE \"Name of test suite\"");
-        testSuite.append("       TESTCASE \"Name of test case\"");
-        testSuite.append("       MOCK CALL 'PROG1'");
-        testSuite.append("          MOVE \"something\" TO this");
-        testSuite.append("          MOVE \"something else\" TO other");
-        testSuite.append("       END-MOCK");
-        testSuite.append("       PERFORM 000-START");
-        testSuite.append("       VERIFY CALL 'PROG1' HAPPENED ONCE");
+        testSuite.append("       TESTSUITE \"Name of test suite\"" + Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       MOCK CALL 'PROG1'"+ Constants.NEWLINE);
+        testSuite.append("          MOVE \"something\" TO this"+ Constants.NEWLINE);
+        testSuite.append("          MOVE \"something else\" TO other"+ Constants.NEWLINE);
+        testSuite.append("       END-MOCK"+ Constants.NEWLINE);
+        testSuite.append("       PERFORM 000-START"+ Constants.NEWLINE);
+        testSuite.append("       VERIFY CALL 'PROG1' HAPPENED ONCE"+ Constants.NEWLINE);
 
         List<String> expectedResult = new ArrayList<>();
         expectedResult.add("           MOVE 1 TO UT-1-1-1-MOCK-EXPECTED");


### PR DESCRIPTION
- Added 'COMP' on certain fields in CCHECKWS.CPY
- Fixed bug, where END-MOCK keywords would be parsed as cobol-token
- Added tests for TestSuiteErrorLogTest