### PR TITLE
Bug fixes and small enhancements

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -25,11 +25,12 @@ cobolcheck.injectedCodeTag.start = null
 cobolcheck.injectedCodeTag.end = null
 
 #---------------------------------------------------------------------------------------------------------------------
-# A tag written at the start of entities stubbed by default.
+# A tag written at the start of entities stubbed by default. Recommended value-length <= 4.
 # Note: The tag will appear only when cobolcheck stubs lines by default.
-# This is the case for CALLs and batch file IO verbs
+# This is the case for CALLs and batch file IO verbs.
+# Default is null, which will prevent the tag from appearing.
 #---------------------------------------------------------------------------------------------------------------------
-cobolcheck.stub.comment.tag = STUB
+cobolcheck.stub.comment.tag = null
 
 #---------------------------------------------------------------------------------------------------------------------
 # Determines if cobolcheck should generate code, such that decimal point is comma.

--- a/config.properties
+++ b/config.properties
@@ -25,6 +25,13 @@ cobolcheck.injectedCodeTag.start = null
 cobolcheck.injectedCodeTag.end = null
 
 #---------------------------------------------------------------------------------------------------------------------
+# A tag written at the start of entities stubbed by default.
+# Note: The tag will appear only when cobolcheck stubs lines by default.
+# This is the case for CALLs and batch file IO verbs
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.stub.comment.tag = STUB
+
+#---------------------------------------------------------------------------------------------------------------------
 # Determines if cobolcheck should generate code, such that decimal point is comma.
 # The default is "false". The value should be set to "true" if the compiler is set to
 # read decimal points as commas. If the cobol source program sets DECIMAL-POINT IS COMMA,
@@ -33,6 +40,14 @@ cobolcheck.injectedCodeTag.end = null
 # Example: 1.385.481,00 (decimalPointIsComma = true)
 #---------------------------------------------------------------------------------------------------------------------
 cobolcheck.decimalPointIsComma = false
+
+#---------------------------------------------------------------------------------------------------------------------
+# If the source program contains rules as the first line follwed by CBL, the given value will be appended
+# to this.
+# If no CBL is found in source, it will be added along with the given value
+# default is null, which will make no changes.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.append.rules = null
 
 #---------------------------------------------------------------------------------------------------------------------
 # Path for the generated Cobol test code

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CobolReader.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CobolReader.java
@@ -19,6 +19,7 @@ public class CobolReader {
     private CobolLine currentLine;
     private List<CobolLine> nextLines;
     private List<CobolLine> currentStatement;
+    private int lineNumber;
 
     private String lineJustEneterd = null;
 
@@ -37,6 +38,7 @@ public class CobolReader {
 
     public String getLineJustEntered() { return lineJustEneterd; }
     boolean hasStatementBeenRead(){ return currentStatement != null; }
+    int getLineNumber() { return lineNumber; }
 
     /**
      * Reads the next line of the cobol file.
@@ -47,6 +49,7 @@ public class CobolReader {
      */
     CobolLine readLine() throws IOException {
         currentStatement = null;
+        lineNumber++;
         if (!nextLines.isEmpty()){
             prevoiusLine = currentLine;
             currentLine = nextLines.get(0);
@@ -109,8 +112,45 @@ public class CobolReader {
     }
 
     /**
+     * Appends the given String to the current line
+     *
+     * @param appendString - The string to append
+     * @return The line, with the given String appended
+     */
+    CobolLine appendToCurrentLine(String appendString){
+        currentLine = new CobolLine(currentLine.getOriginalString() + appendString, tokenExtractor);
+        return currentLine;
+    }
+
+    /**
+     * Turns the current read line into a read statement (if not already a statement).
+     * Adds the given line as the first statement line.
+     * @param line - The line to add
+     */
+    void addLineBeforeCurrentRead(String line){
+        if (currentStatement == null){
+            currentStatement = new ArrayList<>();
+            currentStatement.add(currentLine);
+        }
+        currentStatement.add(0, new CobolLine(line, tokenExtractor));
+    }
+
+    /**
+     * Turns the current read line into a read statement (if not already a statement).
+     * Adds the given line as the last statement line.
+     * @param line - The line to add
+     */
+    void addLineAfterCurrentRead(String line){
+        if (currentStatement == null){
+            currentStatement = new ArrayList<>();
+            currentStatement.add(currentLine);
+        }
+        currentStatement.add(new CobolLine(line, tokenExtractor));
+    }
+
+    /**
      * Peeks the next line of the cobol file that is meaningful - that is; a line that is
-     * not empty or a comment.
+     * not empty nor a comment.
      * Peeking does not alter the reader in any way, thus next time ReadLine() is called,
      * the returned line will not be any different from the one you would have gotten,
      * if you had not peeked.

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
@@ -79,7 +79,10 @@ public class InterpreterController {
     }
 
     public boolean shouldCurrentLineBeParsed(){
-        return Interpreter.shouldLineBeParsed(reader.getCurrentLine(), reader.getState());
+        if (hasStatementBeenRead() && !getCurrentStatement().isEmpty())
+            return Interpreter.shouldLineBeParsed(reader.getCurrentStatement().get(0), reader.getState());
+        else
+            return Interpreter.shouldLineBeParsed(reader.getCurrentLine(), reader.getState());
     }
 
     public boolean shouldCurrentLineBeCommentedOut(){
@@ -188,6 +191,13 @@ public class InterpreterController {
         reader.updateState();
         updateLineRepository(line);
 
+        if (Interpreter.shouldLineBeReadAsStatement(line, reader.getState())){
+            reader.readTillEndOfStatement();
+//            if (!Interpreter.endsInPeriod(lines.get(lines.size() - 1))){
+//                reader.appendNextMeaningfulLineToCurrentLine();
+//            }
+        }
+
         if (reader.isFlagSet(Constants.SPECIAL_NAMES_PARAGRAPH)){
             updateDecimalPointIsComma(line);
         }
@@ -203,6 +213,15 @@ public class InterpreterController {
     }
 
     private void updateDecimalPointIsComma(CobolLine line) {
+        List<String> orderedDecimalIsCommaKeywords = Arrays.asList(Constants.DECIMAL_POINT_KEYWORD,
+                Constants.IS_TOKEN, Constants.COMMA_KEYWORD);
+
+        if (line.containsAllTokensInConsecutiveOrder(orderedDecimalIsCommaKeywords)){
+            Config.setDecimalPointIsComma(true);
+        }
+    }
+
+    private void updateReplaceStatement(CobolLine line) {
         List<String> orderedDecimalIsCommaKeywords = Arrays.asList(Constants.DECIMAL_POINT_KEYWORD,
                 Constants.IS_TOKEN, Constants.COMMA_KEYWORD);
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
@@ -85,13 +85,13 @@ public class InterpreterController {
             return Interpreter.shouldLineBeParsed(reader.getCurrentLine(), reader.getState());
     }
 
-    public boolean shouldCurrentLineBeCommentedOut(){
-        return Interpreter.shouldLineBeCommentedOut(reader.getCurrentLine(), reader.getState());
+    public boolean shouldCurrentLineBeStubbed(){
+        return Interpreter.shouldLineBeStubbed(reader.getCurrentLine(), reader.getState());
     }
 
-    public boolean shouldCurrentStatementBeCommentedOut(){
+    public boolean shouldCurrentStatementBeStubbed(){
         for (CobolLine line : reader.getCurrentStatement()){
-            if (Interpreter.shouldLineBeCommentedOut(line, reader.getState())){
+            if (Interpreter.shouldLineBeStubbed(line, reader.getState())){
                 return true;
             }
         }
@@ -156,6 +156,10 @@ public class InterpreterController {
                 return null;
             }
 
+            if (reader.getLineNumber() == 1){
+                updateCBLOptions(line);
+            }
+
             if (Interpreter.isMeaningful(line)){
                 updateDependencies(line);
                 hasReadLine = true;
@@ -193,9 +197,6 @@ public class InterpreterController {
 
         if (Interpreter.shouldLineBeReadAsStatement(line, reader.getState())){
             reader.readTillEndOfStatement();
-//            if (!Interpreter.endsInPeriod(lines.get(lines.size() - 1))){
-//                reader.appendNextMeaningfulLineToCurrentLine();
-//            }
         }
 
         if (reader.isFlagSet(Constants.SPECIAL_NAMES_PARAGRAPH)){
@@ -416,6 +417,19 @@ public class InterpreterController {
                 lineRepository.addAccumulatedTokensFromCopyStatementToCopyTokens(line.getOriginalString());
             }
 
+        }
+    }
+
+    private void updateCBLOptions(CobolLine line){
+        String appendOptions = Config.getAppendRulesAndOptions();
+        if (appendOptions != null){
+            if (line.containsToken(Constants.CBL_TOKEN)){
+                line = reader.appendToCurrentLine(", " + appendOptions);
+            }
+            else {
+
+                reader.addLineBeforeCurrentRead("       " + Constants.CBL_TOKEN + " " + appendOptions);
+            }
         }
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -349,7 +349,9 @@ public class Keywords {
                     if (isNumeric) {
                         key = Constants.NUMERIC_LITERAL_KEYWORD;
                     }
-                } else {
+                } else if (key.equals(Constants.ZERO_TOKEN)){
+                    key = Constants.NUMERIC_LITERAL_KEYWORD;
+                }else {
                     if (key.equals("TRUE") || key.equals("FALSE")) {
                         key = Constants.BOOLEAN_VALUE;
                     }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -624,12 +624,14 @@ public class TestSuiteParser {
                     testCaseNumber = 0;
                     mockNumber = 0;
                     nextAction = KeywordAction.NONE;
+                    cobolStatementInProgress = false;
                     break;
                 case NEW_TESTCASE:
                     currentTestCaseName = testSuiteToken;
                     testCaseNumber += 1;
                     mockNumber = 0;
                     nextAction = KeywordAction.NONE;
+                    cobolStatementInProgress = false;
                     break;
             }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
@@ -5,6 +5,7 @@ import org.openmainframeproject.cobolcheck.services.StringHelper;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.List;
 
 public class CobolWriter {
@@ -12,6 +13,9 @@ public class CobolWriter {
     Writer writer;
     private boolean currentLineIsComment;
     private final int maxLineLength = 72;
+
+    private boolean storeLines = false;
+    private final List<String> storedLines = new ArrayList<>();
 
     public CobolWriter(Writer writer){
         this.writer = writer;
@@ -28,7 +32,10 @@ public class CobolWriter {
         line = StringHelper.removeTrailingSpaces(line);
         if (line.length() <= maxLineLength){
             line = StringHelper.fixedLength(line);
-            writer.write(line);
+            if (storeLines)
+                storedLines.add(line);
+            else
+                writer.write(line);
         }
         else {
             //We need to check if this line is to be commented out or if it is already a comment
@@ -36,6 +43,27 @@ public class CobolWriter {
             writeMultiLine(line, currentLineIsComment, false);
         }
         currentLineIsComment = false;
+    }
+
+    /**
+     * Puts the writer in a state, where lines will be stored for later user, rather than written,
+     * to the file.
+     */
+    public void startStoringLines(){
+        storeLines = true;
+    }
+
+    /**
+     * Puts the writer in a state, where lines will be stored for later user, rather than written,
+     * to the file.
+     */
+    public void stopStoringLines() {
+        storeLines = false;
+    }
+
+    public void releaseStoredLines() throws IOException {
+        writeLines(storedLines);
+        storedLines.clear();
     }
 
     /**

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
@@ -1,5 +1,6 @@
 package org.openmainframeproject.cobolcheck.features.writer;
 
+import org.openmainframeproject.cobolcheck.services.Config;
 import org.openmainframeproject.cobolcheck.services.cobolLogic.Interpreter;
 import org.openmainframeproject.cobolcheck.services.StringHelper;
 
@@ -16,9 +17,11 @@ public class CobolWriter {
 
     private boolean storeLines = false;
     private final List<String> storedLines = new ArrayList<>();
+    private final String stubTag;
 
     public CobolWriter(Writer writer){
         this.writer = writer;
+        stubTag = Config.getStubTag();
     }
 
     /**
@@ -46,7 +49,7 @@ public class CobolWriter {
     }
 
     /**
-     * Puts the writer in a state, where lines will be stored for later user, rather than written,
+     * Puts the writer in a state, where lines will be stored for later use, rather than written,
      * to the file.
      */
     public void startStoringLines(){
@@ -54,13 +57,15 @@ public class CobolWriter {
     }
 
     /**
-     * Puts the writer in a state, where lines will be stored for later user, rather than written,
-     * to the file.
+     * Makes the writer write lines, instead of storing them.
      */
     public void stopStoringLines() {
         storeLines = false;
     }
 
+    /**
+     * Writes all stored lines, and clears the stored lines.
+     */
     public void releaseStoredLines() throws IOException {
         writeLines(storedLines);
         storedLines.clear();
@@ -76,6 +81,18 @@ public class CobolWriter {
     void writeCommentedLine(String line) throws IOException {
         currentLineIsComment = true;
         writeLine(StringHelper.commentOutLine(line));
+    }
+
+    /**
+     * Writes an out-commented line with a stub-tag to the test output file. If the given line is too
+     * long for cobol to handle, it will be correctly split into multiple lines.
+     *
+     * @param line - line to be commented out and then written
+     * @throws IOException - pass any IOExceptions to the caller.
+     */
+    void writeStubbedLine(String line) throws IOException {
+        currentLineIsComment = true;
+        writeLine(StringHelper.stubLine(line, stubTag));
     }
 
     void writeFormattedLine(String format, Object... args) throws IOException {
@@ -106,6 +123,20 @@ public class CobolWriter {
     void writeCommentedLines(List<String> lines) throws IOException {
         for (String line : lines){
             writeCommentedLine(line);
+        }
+    }
+
+    /**
+     * Comments out and adds a stub-tag and writes all the given lines of cobol code to the test output file.
+     * If the any of the lines are too long for cobol to handle, it will be correctly
+     * split into multiple lines.
+     *
+     * @param lines - lines to be commented out, then written
+     * @throws IOException - pass any IOExceptions to the caller.
+     */
+    void writeStubbedLines(List<String> lines) throws IOException {
+        for (String line : lines){
+            writeStubbedLine(line);
         }
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/writer/WriterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/writer/WriterController.java
@@ -18,10 +18,20 @@ public class WriterController {
         this.cobolWriter = cobolWriter;
     }
 
+    /**
+     * Puts the writer in a state, where lines will be stored for later use, rather than written,
+     * to the file.
+     */
     public void startStoringLines(){ cobolWriter.startStoringLines(); }
 
+    /**
+     * Makes the writer write lines, instead of storing them.
+     */
     public void stopStoringLines() { cobolWriter.stopStoringLines(); }
 
+    /**
+     * Writes all stored lines, and clears the stored lines.
+     */
     public void releaseStoredLines() throws IOException { cobolWriter.releaseStoredLines(); }
 
     /**
@@ -43,6 +53,15 @@ public class WriterController {
     public void writeCommentedLine(String line) throws IOException { cobolWriter.writeCommentedLine(line); }
 
     /**
+     * Writes an out-commented line with a stub-tag to the test output file. If the given line is too
+     * long for cobol to handle, it will be correctly split into multiple lines.
+     *
+     * @param line - line to be commented out and then written
+     * @throws IOException - pass any IOExceptions to the caller.
+     */
+    public void writeStubbedLine(String line) throws IOException { cobolWriter.writeStubbedLine(line); }
+
+    /**
      * Writes all the given lines of cobol code to the test output file. If the any of the lines
      * are too long for cobol to handle, it will be correctly split into multiple lines.
      *
@@ -62,6 +81,16 @@ public class WriterController {
     public void writeCommentedLines(List<String> lines) throws IOException {
         cobolWriter.writeCommentedLines(lines);
     }
+
+    /**
+     * Comments out and adds a stub-tag and writes all the given lines of cobol code to the test output file.
+     * If the any of the lines are too long for cobol to handle, it will be correctly
+     * split into multiple lines.
+     *
+     * @param lines - lines to be commented out, then written
+     * @throws IOException - pass any IOExceptions to the caller.
+     */
+    public void writeStubbedLines(List<String> lines) throws IOException { cobolWriter.writeStubbedLines(lines); }
 
     public void closeWriter(String programName) {
         try {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/writer/WriterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/writer/WriterController.java
@@ -4,6 +4,7 @@ import org.openmainframeproject.cobolcheck.exceptions.PossibleInternalLogicError
 import org.openmainframeproject.cobolcheck.services.Messages;
 
 import java.io.*;
+import java.util.ArrayList;
 import java.util.List;
 
 public class WriterController {
@@ -16,6 +17,12 @@ public class WriterController {
     public WriterController(CobolWriter cobolWriter){
         this.cobolWriter = cobolWriter;
     }
+
+    public void startStoringLines(){ cobolWriter.startStoringLines(); }
+
+    public void stopStoringLines() { cobolWriter.stopStoringLines(); }
+
+    public void releaseStoredLines() throws IOException { cobolWriter.releaseStoredLines(); }
 
     /**
      * Writes a line of cobol code to the test output file. If the given line is too

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
@@ -24,8 +24,10 @@ import java.util.Properties;
 public class Config {
 
     public static final String DECIMAL_POINT_IS_COMMA_CONFIG_KEY = "cobolcheck.decimalPointIsComma";
+    public static final String APPEND_RULES_AND_OPTIONS = "cobolcheck.append.rules";
     public static final String INJECT_START_TAG_CONFIG_KEY = "cobolcheck.injectedCodeTag.start";
     public static final String INJECT_END_TAG_CONFIG_KEY = "cobolcheck.injectedCodeTag.end";
+    public static final String STUB_COMMENT_TAG = "cobolcheck.stub.comment.tag";
     public static final String GENERATED_CODE_PATH = "cobolcheck.test.program.path";
     public static final String TESTSUITEPARSER_ERROR_LOG_PATH = "testsuite.parser.error.log.path";
     public static final String TESTSUITEPARSER_ERROR_LOG_NAME = "testsuite.parser.error.log.name";
@@ -128,6 +130,14 @@ public class Config {
         decimalPointIsComma = value;
     }
 
+    public static  String getAppendRulesAndOptions() {
+        String value = settings.getProperty(APPEND_RULES_AND_OPTIONS, "NULL");
+        if (value.trim().toUpperCase(Locale.ROOT).equals("NULL")){
+            return null;
+        }
+        return value;
+    }
+
     public static String getTestSuiteDirectoryPathString() {
         return StringHelper.adjustPathString(settings.getProperty(TEST_SUITE_DIRECTORY_CONFIG_KEY,
                 Constants.CURRENT_DIRECTORY));
@@ -171,6 +181,14 @@ public class Config {
     public static String getInjectEndTag(){
         return StringHelper.adjustPathString(settings.getProperty(INJECT_END_TAG_CONFIG_KEY,
                 Constants.CURRENT_DIRECTORY));
+    }
+
+    public static String getStubTag() {
+        String value = settings.getProperty(STUB_COMMENT_TAG, "NULL");
+        if (value.trim().toUpperCase(Locale.ROOT).equals("NULL")){
+            return "";
+        }
+        return value;
     }
 
     public static String getTestResultFilePathString() {

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -137,6 +137,7 @@ public final class Constants {
     public static final String END_CALL_TOKEN = "END-CALL";
     public static final String ZERO_TOKEN = "ZERO";
     public static final String REPLACE_TOKEN = "REPLACE";
+    public static final String CBL_TOKEN = "CBL";
 
     public static final String COMP_3_VALUE = "COMP-3";
     public static final String COMP_VALUE = "COMP";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -136,6 +136,7 @@ public final class Constants {
     public static final String END_PARAGRAPH_TOKEN = "END-PARAGRAPH";
     public static final String END_CALL_TOKEN = "END-CALL";
     public static final String ZERO_TOKEN = "ZERO";
+    public static final String REPLACE_TOKEN = "REPLACE";
 
     public static final String COMP_3_VALUE = "COMP-3";
     public static final String COMP_VALUE = "COMP";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
@@ -152,6 +152,41 @@ public class StringHelper {
 
     }
 
+    public static String stubLine(String line, String stubTag){
+        if (stubTag == null || stubTag.isEmpty())
+            return commentOutLine(line);
+
+        int stubTagLength = stubTag.length();
+        if (line.startsWith("       ")){
+            int leadingSpaceIndex = getNumberOfLeadingSpaces(line.substring(Constants.COMMENT_SPACE_OFFSET));
+            if (stubTagLength <= leadingSpaceIndex)
+                return "      *" + stubTag + line.substring(Constants.COMMENT_SPACE_OFFSET + stubTagLength);
+            else
+                return "      *" + stubTag + line.substring(Constants.COMMENT_SPACE_OFFSET + leadingSpaceIndex);
+        }
+        if (line.startsWith("      *")){
+            int starIndex = line.indexOf('*');
+            int leadingSpaceIndex = getNumberOfLeadingSpaces(line.substring(starIndex + 1));
+            if (stubTagLength <= leadingSpaceIndex)
+                return line.substring(0, starIndex + 1) + stubTag + line.substring(starIndex + 1 + stubTagLength);
+            else
+                return line.substring(0, starIndex + 1) + stubTag + line.substring(starIndex + 1 + leadingSpaceIndex);
+        }
+        else {
+            return "      *" + stubTag + line;
+        }
+    }
+
+    public static int getNumberOfLeadingSpaces(String line){
+        char[] characters = line.toCharArray();
+        int index = 0;
+
+        while (characters[index] == ' '){
+            index++;
+        }
+        return index;
+    }
+
     /**
      * Enclose a value in quotation marks.
      *

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
@@ -234,10 +234,16 @@ public class Interpreter {
         if (isTooShortToBeMeaningful(line) && line.tokensSize() > 0){
             return false;
         }
-        if (state.isFlagSetFor(Constants.FILE_SECTION)){
+        if (state.isFlagSetFor(Constants.FILE_SECTION) && ! (line.containsToken(Constants.FILE_SECTION))){
+            if (line.containsToken(Constants.REPLACE_TOKEN))
+                return true;
+
             return false;
         }
-        if (state.isFlagSetFor(Constants.FILE_CONTROL)){
+        if (state.isFlagSetFor(Constants.FILE_CONTROL)&& ! (line.containsToken(Constants.FILE_CONTROL))){
+            if (line.containsToken(Constants.REPLACE_TOKEN))
+                return true;
+
             return false;
         }
 
@@ -255,6 +261,19 @@ public class Interpreter {
             {
                 return true;
             }
+        }
+        return false;
+    }
+
+    /**
+     * @param line
+     * @param state
+     * @return true if the source line should be commented out
+     */
+    public static boolean shouldLineBeReadAsStatement(CobolLine line, State state){
+        if (state.isFlagSetFor(Constants.FILE_SECTION) || state.isFlagSetFor(Constants.FILE_CONTROL)){
+            if (line.containsToken(Constants.REPLACE_TOKEN))
+                return true;
         }
         return false;
     }

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
@@ -255,7 +255,7 @@ public class Interpreter {
      * @param state
      * @return true if the source line should be commented out
      */
-    public static boolean shouldLineBeCommentedOut(CobolLine line, State state){
+    public static boolean shouldLineBeStubbed(CobolLine line, State state){
         if (state.isFlagSetFor(Constants.PROCEDURE_DIVISION)){
             if (checkForBatchFileIOStatement(line) || line.containsToken(Constants.CALL_TOKEN))
             {

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
@@ -154,8 +154,8 @@ public class Generator {
     private void writeToSource(String sourceLine) throws IOException {
         if (interpreter.shouldCurrentLineBeParsed()) {
             if (interpreter.hasStatementBeenRead()){
-                if (interpreter.shouldCurrentStatementBeCommentedOut()){
-                    writerController.writeCommentedLines(interpreter.getCurrentStatement());
+                if (interpreter.shouldCurrentStatementBeStubbed()){
+                    writerController.writeStubbedLines(interpreter.getCurrentStatement());
                 }
                 else {
                     writerController.writeLines(interpreter.getCurrentStatement());
@@ -163,8 +163,8 @@ public class Generator {
             }
 
             else {
-                if (interpreter.shouldCurrentLineBeCommentedOut()){
-                    writerController.writeCommentedLine(sourceLine);
+                if (interpreter.shouldCurrentLineBeStubbed()){
+                    writerController.writeStubbedLine(sourceLine);
                 }
                 else {
                     writerController.writeLine(sourceLine);

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
@@ -119,9 +119,14 @@ public class Generator {
                 writerController.writeLines(testSuiteParserController.getWorkingStorageTestCode(
                         interpreter.getFileSectionStatements()));
             }
+            writerController.startStoringLines();
+            workingStorageHasEnded = true;
+        }
+        if (interpreter.didLineJustEnter(Constants.PROCEDURE_DIVISION) && interpreter.currentLineContains(Constants.PROCEDURE_DIVISION)){
+            writerController.stopStoringLines();
             testSuiteParserController.parseTestSuites(interpreter.getNumericFields());
             writerController.writeLines(testSuiteParserController.getWorkingStorageMockCode());
-            workingStorageHasEnded = true;
+            writerController.releaseStoredLines();
         }
     }
 
@@ -148,7 +153,6 @@ public class Generator {
      */
     private void writeToSource(String sourceLine) throws IOException {
         if (interpreter.shouldCurrentLineBeParsed()) {
-
             if (interpreter.hasStatementBeenRead()){
                 if (interpreter.shouldCurrentStatementBeCommentedOut()){
                     writerController.writeCommentedLines(interpreter.getCurrentStatement());

--- a/src/test/cobol/MOCKTEST/GeneralTest.cut
+++ b/src/test/cobol/MOCKTEST/GeneralTest.cut
@@ -1,5 +1,8 @@
            TestSuite "General tests"
 
+           TestCase "No Expect or Verify"
+           PERFORM 100-WELCOME
+
            TestCase "Welcome section performs as intended"
            PERFORM 100-WELCOME
            Expect VALUE-1 to be "Hello"

--- a/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
+++ b/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
@@ -19,6 +19,7 @@
            Expect VALUE-1 to be "Hi"
            Expect VALUE-2 to be "Hello"
            VERIFY SECTION 000-START HAPPENED ONCE
+           VERIFY PARAGRAPH 300-CHANGE-1 HAPPENED ZERO TIMES
 
            TestCase "Local mock overwrites global mock"
            MOCK SECTION 000-START

--- a/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
@@ -1,5 +1,6 @@
 package org.openmainframeproject.cobolcheck;
 
+import org.mockito.MockedStatic;
 import org.openmainframeproject.cobolcheck.exceptions.PossibleInternalLogicErrorException;
 import org.openmainframeproject.cobolcheck.features.interpreter.InterpreterController;
 import org.openmainframeproject.cobolcheck.services.Config;
@@ -103,6 +104,135 @@ public class InterpreterControllerTest {
 
         assertTrue(Config.isDecimalPointComma());
         assertFalse(interpreterController.isReading(Constants.SPECIAL_NAMES_PARAGRAPH));
+    }
+
+    @Test
+    public void it_sets_CBL_rules_on_first_line() throws IOException {
+        String str1 = "       IDENTIFICATION DIVISION.";
+
+        MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getAppendRulesAndOptions())
+                .thenReturn("OPT(0), RULES(LAXPERF)");
+
+        List<String> expected = new ArrayList<>();
+        expected.add("       CBL OPT(0), RULES(LAXPERF)");
+        expected.add("       IDENTIFICATION DIVISION.");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, null);
+
+        String line = "";
+        boolean assertHappened = false;
+        while ((line =interpreterController.interpretNextLine()) != null){
+            if (line != null){
+                assertHappened = true;
+                assertEquals(expected, interpreterController.getCurrentStatement());
+            }
+        }
+        mockedConfig.close();
+        assertTrue(assertHappened);
+    }
+
+    @Test
+    public void it_sets_CBL_rules_on_first_line_when_empty() throws IOException {
+        String str1 = "";
+        String str2 = "       IDENTIFICATION DIVISION.";
+
+        MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getAppendRulesAndOptions())
+                .thenReturn("OPT(0), RULES(LAXPERF)");
+
+        List<String> expected = new ArrayList<>();
+        expected.add("       CBL OPT(0), RULES(LAXPERF)");
+        expected.add("");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, null);
+
+        String line = "";
+        boolean assertHappened = false;
+        while ((line =interpreterController.interpretNextLine()) != null){
+            if (line != null && line.isEmpty()){
+                assertHappened = true;
+                assertEquals(expected, interpreterController.getCurrentStatement());
+            }
+        }
+        mockedConfig.close();
+        assertTrue(assertHappened);
+    }
+
+    @Test
+    public void it_sets_CBL_rules_on_first_line_when_it_is_a_comment() throws IOException {
+        String str1 = "      * This is a comment";
+        String str2 = "       IDENTIFICATION DIVISION.";
+
+        MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getAppendRulesAndOptions())
+                .thenReturn("OPT(0), RULES(LAXPERF)");
+
+        List<String> expected = new ArrayList<>();
+        expected.add("       CBL OPT(0), RULES(LAXPERF)");
+        expected.add("      * This is a comment");
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, null);
+
+        String line = "";
+        boolean assertHappened = false;
+        while ((line =interpreterController.interpretNextLine()) != null){
+            if (line != null && line.equals(str1)){
+                assertHappened = true;
+                assertEquals(expected, interpreterController.getCurrentStatement());
+            }
+        }
+        mockedConfig.close();
+        assertTrue(assertHappened);
+    }
+
+    @Test
+    public void it_appends_CBL_rules_on_first_line_if_it_is_already_there() throws IOException {
+        String str1 = "       CBL OPT(1)";
+
+        MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getAppendRulesAndOptions())
+                .thenReturn("OPT(0), RULES(LAXPERF)");
+
+        String expected = "       CBL OPT(1), OPT(0), RULES(LAXPERF)";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, null);
+
+        String line = "";
+        boolean assertHappened = false;
+        while ((line =interpreterController.interpretNextLine()) != null){
+            if (line != null){
+                assertHappened = true;
+                assertEquals(expected, line);
+            }
+        }
+        mockedConfig.close();
+        assertTrue(assertHappened);
+    }
+
+    @Test
+    public void it_does_not_add_CBL_rules_on_first_line_if_null_is_given() throws IOException {
+        String str1 = "       IDENTIFICATION DIVISION.";
+
+        MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getAppendRulesAndOptions())
+                .thenReturn(null);
+
+        String expected = "       IDENTIFICATION DIVISION.";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, null);
+
+        String line = "";
+        boolean assertHappened = false;
+        while ((line =interpreterController.interpretNextLine()) != null){
+            if (line != null){
+                assertHappened = true;
+                assertTrue(!interpreterController.hasStatementBeenRead());
+                assertEquals(expected, line);
+            }
+        }
+        mockedConfig.close();
+        assertTrue(assertHappened);
     }
 
     @Test

--- a/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
@@ -309,6 +309,48 @@ public class InterpreterControllerTest {
     }
 
     @Test
+    public void it_lets_replace_statements_in_file_section_be_parsed() throws IOException {
+
+        String str1 = "       DATA DIVISION.";
+        String str2 = "       FILE SECTION.";
+        String str3 = "               REPLACE ==TEST== BY ==test==";
+        String str4 = "                       ==TEST== BY ==test==";
+        String str5 = "               .";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
+
+        boolean foundReplace = false;
+        String line = "";
+        while ((line = interpreterController.interpretNextLine()) != null){
+            if (line != null && interpreterController.hasStatementBeenRead()){
+                foundReplace = true;
+                assertTrue(interpreterController.shouldCurrentLineBeParsed());
+                assertEquals(interpreterController.getCurrentStatement().get(0), str3);
+                assertEquals(interpreterController.getCurrentStatement().get(1), str4);
+                assertEquals(interpreterController.getCurrentStatement().get(2), str5);
+            }
+
+        }
+        assertTrue(foundReplace);
+    }
+
+    @Test
+    public void it_lets_replace_statements_in_file_section_be_parsed_with_period_inside_replace() throws IOException {
+
+        String str1 = "       DATA DIVISION.";
+        String str2 = "       FILE SECTION.";
+        String str3 = "               REPLACE ==A.B== BY ==B.A==.";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, null);
+
+        while (interpreterController.interpretNextLine() != null){
+            interpreterController.interpretNextLine();
+        }
+
+        assertTrue(interpreterController.shouldCurrentLineBeParsed());
+    }
+
+    @Test
     public void it_throws_when_token_list_has_fewer_than_2_entries() throws IOException {
         String str1 = "       FILE SECTION.";
         String str2 = "       FD  OUTPUT-FILE";

--- a/src/test/java/org/openmainframeproject/cobolcheck/StringHelperTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/StringHelperTest.java
@@ -90,4 +90,67 @@ public class StringHelperTest{
         String original = "src/main/cobol/";
         assertEquals(expected, StringHelper.adjustPathString(original));
     }
+
+    @Test
+    public void it_stubs_a_line_that_starts_with_spaces() {
+        String expected = "      *STUBCALL 'PROG1'.";
+        String original = "           CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUB"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_starts_with_spaces_short_stub_tag() {
+        String expected = "      *ST  CALL 'PROG1'.";
+        String original = "           CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "ST"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_starts_with_spaces_long_stub_tag() {
+        String expected = "      *STUBBEDVALUECALL 'PROG1'.";
+        String original = "           CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUBBEDVALUE"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_is_already_a_comment() {
+        String expected = "      *STUBCALL 'PROG1'.";
+        String original = "      *    CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUB"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_is_already_a_comment_short_stub_tag() {
+        String expected = "      *ST  CALL 'PROG1'.";
+        String original = "      *    CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "ST"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_is_already_a_comment_long_stub_tag() {
+        String expected = "      *STUBBEDVALUECALL 'PROG1'.";
+        String original = "      *    CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUBBEDVALUE"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_starts_without_spaces() {
+        String expected = "      *STUBCALL 'PROG1'.";
+        String original = "CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUB"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_starts_without_spaces_short_stub_tag() {
+        String expected = "      *STCALL 'PROG1'.";
+        String original = "CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "ST"));
+    }
+
+    @Test
+    public void it_stubs_a_line_that_starts_without_spaces_long_stub_tag() {
+        String expected = "      *STUBBEDVALUECALL 'PROG1'.";
+        String original = "CALL 'PROG1'.";
+        assertEquals(expected, StringHelper.stubLine(original, "STUBBEDVALUE"));
+    }
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserParsingTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserParsingTest.java
@@ -23,8 +23,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TestSuiteParserParsingTest {
@@ -167,6 +166,20 @@ public class TestSuiteParserParsingTest {
         assertEquals(expectedLine, actual.get(2));
     }
 
+    @Test
+    public void it_generates_lines_correctly_for_empty_testcase_followed_by_testcase() {
+        testSuite.append("       TESTSUITE \"Name of test suite\"");
+        testSuite.append("       TESTCASE \"Name of test case\"");
+        testSuite.append("       PERFORM 000-START");
+        testSuite.append("       TESTCASE \"Name of test case1\"");
+        testSuite.append( "       PERFORM 000-START");
+        testSuite.append( "       EXPECT value-1 TO BE 'hi'");
+
+        List<String> actualResult = testSuiteParser.getParsedTestSuiteLines(
+                new BufferedReader(new StringReader(testSuite.toString())),
+                numericFields);
+        assertTrue(!actualResult.contains("            \"Name of test case1\""));
+    }
 
 
     @Test


### PR DESCRIPTION
- Added config option for `CBL` rules and options, as the first line of the generated program.
- Added a config option for a stub-tag, that will be added to all lines that are stubbed by default.
- Fixed bug, where if an `EXPECT `referenced a numeric type from the `LINKAGE SECTION`, it would be picked up as an alphanumeric value instead, due to the `LINKAGE SECTION` not having been read at that point in time. Now the whole `DATA DIVISION` is read before processing TestSuites.
- Fixed bug, where a testcase with no `EXPECT `or `VERIFY`, would make the following testcase write the testcase name out of context.
- Fixed bug, where a `REPLACE `in the `FILE CONTROL` or `FILE SECTION` would not get parsed.
- Fixed bug, where the `ZERO`-token would be classified as a cobol-statement instead of numeric.