### PR TITLE
StringTokenizerExtractor sees String as a single token

### DIFF
--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/StringTokenizerExtractor.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/StringTokenizerExtractor.java
@@ -46,6 +46,7 @@ public class StringTokenizerExtractor implements TokenExtractor {
      * Such "meaningful" tokens may comprise more than one "plain" token,
      * such as "PROCEDURE DIVISION" or "INPUT-OUTPUT SECTION" - treated as a single token here.
      *
+     * Strings are treated as a single token.
      * Commented lines are ignored.
      *
      * @param sourceLine (String) - passed by a component that reads Cobol source files, assumed to be upper case.
@@ -63,6 +64,8 @@ public class StringTokenizerExtractor implements TokenExtractor {
         List<String> tokens = new ArrayList<>();
         List<String> expectedNext = new ArrayList<>();
         String saved = Constants.EMPTY_STRING;
+        Map<String, String> stringTokensToString = new HashMap<>();
+        sourceLine = swapStringsOutWithMappedTokens(sourceLine, stringTokensToString);
         StringTokenizer tokenizer = new StringTokenizer(sourceLine, delimiters);
         while (tokenizer.hasMoreTokens()) {
             String token = tokenizer.nextToken().toUpperCase(Locale.ROOT);
@@ -85,6 +88,80 @@ public class StringTokenizerExtractor implements TokenExtractor {
                 tokens.add(token);
             }
         }
+        swapMappedTokensOutWithSavedStrings(tokens, stringTokensToString);
         return tokens;
+    }
+
+    /**
+     * Swaps out strings in the given line, with tags, so each string will be seen as a single
+     * token, when extracting tokens. Additionally, spaces are added to each side of string-signs.
+     *
+     * Each tag is mapped to the original string, so that the original values can be placed again
+     * after the extraction.
+     *
+     * @param line - Line for which to swap string values
+     * @param stringTokensToString - Map of tags to original string values
+     * @return The new line, with the strings swapped for tags
+     */
+    private String swapStringsOutWithMappedTokens(String line, Map<String, String> stringTokensToString){
+        int stringCount = 0;
+        boolean insideString = false;
+        char stringSign = ' ';
+        String newString = "";
+        String currentRealString = "";
+        String mapValue = "";
+        for (char c : line.toCharArray()){
+            if (c == '\''){
+                if (insideString){
+                    currentRealString += c;
+                    if (stringSign == '\''){
+                        insideString = false;
+                        stringSign = ' ';
+                        stringTokensToString.put(mapValue, currentRealString);
+                    }
+                }
+                else if (!insideString){
+                    insideString = true;
+                    stringSign = '\'';
+                    currentRealString = String.valueOf(c);
+                    mapValue = "" + c + "STRING" + stringCount + c;
+                    stringCount++;
+                    newString += " " + mapValue + " ";
+                }
+            }
+            else if (c == '"'){
+                if (insideString){
+                    currentRealString += c;
+                    if (stringSign == '"'){
+                        insideString = false;
+                        stringSign = ' ';
+                        stringTokensToString.put(mapValue, currentRealString);
+                    }
+                }
+                else if (!insideString){
+                    insideString = true;
+                    stringSign = '"';
+                    currentRealString = String.valueOf(c);
+                    mapValue = "" + c + "STRING" + stringCount + c;
+                    stringCount++;
+                    newString += " " + mapValue + " ";
+                }
+            }
+            else {
+                if (insideString)
+                    currentRealString += c;
+                else
+                    newString += c;
+            }
+        }
+        return newString;
+    }
+
+    private void swapMappedTokensOutWithSavedStrings(List<String> tokens, Map<String, String> stringTokensToString){
+        for(int i = 0; i < tokens.size(); i++){
+            if (stringTokensToString.containsKey(tokens.get(i))){
+                tokens.set(i, stringTokensToString.get(tokens.get(i)));
+            }
+        }
     }
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/StringTokenizerExtractorTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/StringTokenizerExtractorTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +49,112 @@ public class StringTokenizerExtractorTest {
     @Test
     public void when_the_line_contains_only_a_period_it_returns_an_empty_collection() {
         assertEquals(0, extractor.extractTokensFrom(Constants.PERIOD).size());
+    }
+
+    @Test
+    public void it_gets_a_simple_string_as_token() {
+        String line = "MOVE 'hello there' TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("'hello there'");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void it_gets_a_long_string_as_token() {
+        String line = "MOVE \"This is some kind of long string\" TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"This is some kind of long string\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void end_of_token_can_start_string_start_of_token_can_end_string() {
+        String line = "MOVE\" This is some kind of long string \"TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\" This is some kind of long string \"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void only_the_starting_string_char_can_end_the_string_1() {
+        String line = "MOVE \"STRING' STRING\" TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"STRING' STRING\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void only_the_starting_string_char_can_end_the_string_2() {
+        String line = "MOVE \"STRING ' STRING\" TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"STRING ' STRING\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void only_the_starting_string_char_can_end_the_string_3() {
+        String line = "MOVE \"STRING 'STRING\" TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"STRING 'STRING\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void only_the_starting_string_char_can_end_the_string_4() {
+        String line = "MOVE \"THIS WON'T AND CAN'T END THE STRING\" TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"THIS WON'T AND CAN'T END THE STRING\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void strings_without_spaces_is_still_its_own_token() {
+        String line = "MOVE\"HI THERE\"TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"HI THERE\"");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
+    }
+
+    @Test
+    public void many_string_chars_with_varying_spaces() {
+        String line = "MOVE\"HI '''THERE'\"+'HEY\"YOU\"' +\"''''\"\"''''\"+' HI' TO VALUE-1";
+        List<String> expected = new ArrayList<>();
+        expected.add("MOVE");
+        expected.add("\"HI '''THERE'\"");
+        expected.add("+");
+        expected.add("'HEY\"YOU\"'");
+        expected.add("+");
+        expected.add("\"''''\"");
+        expected.add("\"''''\"");
+        expected.add("+");
+        expected.add("' HI'");
+        expected.add("TO");
+        expected.add("VALUE-1");
+        assertEquals(expected, extractor.extractTokensFrom(line));
     }
 
     @Test


### PR DESCRIPTION
- Fixed bug, where the StringTokenizerExtractor would not treat strings as a single token. This could lead the Interpreter to finding keywords inside strings.

