### PR TITLE
Cobol check integration into vs code extension

### DIFF
--- a/CC##99.CBL
+++ b/CC##99.CBL
@@ -5,6 +5,7 @@
       *****************************************************************         
        ENVIRONMENT DIVISION.                                                    
        INPUT-OUTPUT SECTION.                                                    
+       FILE-CONTROL.                                                            
        DATA DIVISION.                                                           
        WORKING-STORAGE SECTION.                                                 
       * CCHECKWS.CPY                                                            
@@ -509,6 +510,16 @@
            DISPLAY "General tests"                                              
            MOVE "General tests"                                                 
                TO UT-TEST-SUITE-NAME                                            
+      *-------- "No Expect or Verify"                                           
+           MOVE SPACES                                                          
+               TO UT-TEST-CASE-NAME                                             
+           PERFORM UT-BEFORE-EACH                                               
+           MOVE "No Expect or Verify"                                           
+               TO UT-TEST-CASE-NAME                                             
+           PERFORM UT-INITIALIZE-MOCK-COUNT                                     
+           MOVE SPACES                                                          
+               TO UT-TEST-CASE-NAME                                             
+           PERFORM UT-AFTER-EACH                                                
       *-------- "Welcome section performs as intended"                          
            MOVE SPACES                                                          
                TO UT-TEST-CASE-NAME                                             
@@ -957,6 +968,13 @@
            MOVE UT-6-0-1-MOCK-COUNT TO UT-ACTUAL-ACCESSES                       
            MOVE UT-6-0-1-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES                  
            MOVE UT-6-0-1-MOCK-NAME TO UT-MOCK-OPERATION                         
+           SET UT-VERIFY-EXACT TO TRUE                                          
+           ADD 1 TO UT-TEST-CASE-COUNT                                          
+           PERFORM UT-ASSERT-ACCESSES                                           
+           MOVE ZERO TO UT-6-0-2-MOCK-EXPECTED                                  
+           MOVE UT-6-0-2-MOCK-COUNT TO UT-ACTUAL-ACCESSES                       
+           MOVE UT-6-0-2-MOCK-EXPECTED TO UT-EXPECTED-ACCESSES                  
+           MOVE UT-6-0-2-MOCK-NAME TO UT-MOCK-OPERATION                         
            SET UT-VERIFY-EXACT TO TRUE                                          
            ADD 1 TO UT-TEST-CASE-COUNT                                          
            PERFORM UT-ASSERT-ACCESSES                                           

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandler.java
@@ -6,6 +6,7 @@ import org.openmainframeproject.cobolcheck.services.Config;
 import org.openmainframeproject.cobolcheck.services.Constants;
 import org.openmainframeproject.cobolcheck.services.Messages;
 import org.openmainframeproject.cobolcheck.services.StringHelper;
+import org.openmainframeproject.cobolcheck.services.log.Log;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,7 +38,10 @@ public class ArgumentHandler {
      */
     public ArgumentHandler(String[] args, String optionsString) {
         options = new HashMap<>();
-        if (StringHelper.isEmptyArray(args)) return;
+        Log.debug("Running with arguments: " + Arrays.toString(args));
+        if (StringHelper.isEmptyArray(args))
+            return;
+
         storeOptionSettings(optionsString);
         processCommandLineArgumentArray(args);
     }
@@ -145,7 +149,7 @@ public class ArgumentHandler {
                 for (String program : programArgs.split(Constants.COLON)){
                     newValue += StringHelper.adjustPathString(applicationSourceDirectory +
                             Constants.FILE_SEPARATOR + program);
-                    newValue += Constants.COLON;
+                    newValue += "|";
                 }
                 options.get(optionKey).argumentValue = newValue.substring(0, newValue.length()-1);
             }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandlerController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandlerController.java
@@ -15,9 +15,6 @@ public class ArgumentHandlerController {
     }
 
     public void loadSettingsFromArguments() {
-        //Load paths in program values
-        argumentHandler.loadArgProgramPaths();
-
         //Overwrite settings from config file
         if (isKeySet("generated-tests"))
             Config.setGeneratedTestFileName(getKeyValue("generated-tests"));
@@ -32,6 +29,12 @@ public class ArgumentHandlerController {
         if (isKeySet("error-log")){
             Config.setTestSuiteParserErrorLogFileName(getKeyValue("error-log"));
         }
+        if (isKeySet("source-context")){
+            Config.setSourceFolderContext(getKeyValue("source-context"));
+        }
+
+        //Load paths in program values
+        argumentHandler.loadArgProgramPaths();
     }
 
     public boolean isKeySet(String key){

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CopybookExpander.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CopybookExpander.java
@@ -5,6 +5,7 @@ import org.openmainframeproject.cobolcheck.services.Config;
 import org.openmainframeproject.cobolcheck.services.Constants;
 import org.openmainframeproject.cobolcheck.services.Messages;
 import org.openmainframeproject.cobolcheck.services.StringTuple;
+import org.openmainframeproject.cobolcheck.services.filehelpers.PathHelper;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -122,14 +123,7 @@ public class CopybookExpander {
     }
 
     private String getPathToCopybooks() {
-        StringBuilder directoryName = new StringBuilder();
-        directoryName.append(new File("./").getAbsolutePath());
-        directoryName.append(Constants.FILE_SEPARATOR);
-        directoryName.append(Config.getString("application.copybook.directory", "src/main/cobol/copy"));
-        if (!directoryName.toString().endsWith(Constants.FILE_SEPARATOR)) {
-            directoryName.append(Constants.FILE_SEPARATOR);
-        }
-        return directoryName.toString();
+        return PathHelper.endWithFileSeparator(Config.getCopyBookSourceDirectoryPathString());
     }
 
 }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/WindowsProcessLauncher.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/WindowsProcessLauncher.java
@@ -53,7 +53,7 @@ public class WindowsProcessLauncher implements ProcessLauncher {
             scriptDirectory += Constants.FILE_SEPARATOR;
         }
         ProcessBuilder processBuilder = new ProcessBuilder();
-        processBuilder.command(scriptDirectory + scriptName, programName);
+        processBuilder.command(scriptDirectory + scriptName, "\"" + programName + "\"");
 
         Process process = null;
         StringBuilder processArguments = new StringBuilder();

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/prepareMerge/IO_FileGetter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/prepareMerge/IO_FileGetter.java
@@ -71,7 +71,7 @@ public class IO_FileGetter {
      */
     static List<String> getMatchingTestDirectoriesForProgram(String programName){
         // all test suites are located under this directory
-        String testSuiteDirectory = Config.getTestSuiteDirectoryPathString();
+        String testSuiteDirectory = Config.getTestSourceDirectoryPathString();
         testSuiteDirectory = endWithFileSeparator(testSuiteDirectory);
 
         // Find test subdirectories that match program names

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
@@ -2,6 +2,7 @@ package org.openmainframeproject.cobolcheck.services;
 
 import org.openmainframeproject.cobolcheck.features.launcher.Formatter.DataTransferObjects.DataTransferObjectStyle;
 import org.openmainframeproject.cobolcheck.features.launcher.Formatter.Formats.TestOutputFormat;
+import org.openmainframeproject.cobolcheck.services.filehelpers.PathHelper;
 import org.openmainframeproject.cobolcheck.services.log.Log;
 import org.openmainframeproject.cobolcheck.exceptions.IOExceptionProcessingConfigFile;
 import org.openmainframeproject.cobolcheck.exceptions.PossibleInternalLogicErrorException;
@@ -48,12 +49,15 @@ public class Config {
     public static final String APPLICATION_COPYBOOK_FILENAME_SUFFIX = "application.copybook.filename.suffix";
     public static final String NONE = "none";
     public static final String DEFAULT_CONFIG_FILE_PATH = "config.properties";
-    public static final String TEST_SUITE_DIRECTORY_CONFIG_KEY = "test.suite.directory";
     public static final String TEST_RESULTS_FILE_CONFIG_KEY = "test.results.file";
     public static final String TEST_RESULTS_FORMAT_CONFIG_KEY = "test.results.format";
     public static final String TEST_RESULTS_FORMAT_STYLE_CONFIG_KEY = "test.results.format.style";
     public static final String APPLICATION_SOURCE_DIRECTORY_CONFIG_KEY = "application.source.directory";
     public static final String DEFAULT_APPLICATION_SOURCE_DIRECTORY = "src/main/cobol";
+    public static final String COPY_SOURCE_DIRECTORY_CONFIG_KEY = "application.copybook.directory";
+    public static final String DEFAULT_COPY_SOURCE_DIRECTORY = "src/main/cobol/copy";
+    public static final String TESTSUITE_DIRECTORY_CONFIG_KEY = "test.suite.directory";
+    public static final String DEFAULT_TESTSUITE_DIRECTORY = "src/test/cobol";
 
     private static Properties settings = null;
 
@@ -136,11 +140,6 @@ public class Config {
             return null;
         }
         return value;
-    }
-
-    public static String getTestSuiteDirectoryPathString() {
-        return StringHelper.adjustPathString(settings.getProperty(TEST_SUITE_DIRECTORY_CONFIG_KEY,
-                Constants.CURRENT_DIRECTORY));
     }
 
     public static String getGeneratedTestCodePath() {
@@ -270,10 +269,39 @@ public class Config {
                 Constants.CURRENT_DIRECTORY));
         return Boolean.parseBoolean(value.trim());
     }
+    private static String sourceFolderContext = null;
+    public static void setSourceFolderContext(String keyValue) {
+        sourceFolderContext = keyValue;
+    }
 
     public static String getApplicationSourceDirectoryPathString() {
-        return StringHelper.adjustPathString(settings.getProperty(APPLICATION_SOURCE_DIRECTORY_CONFIG_KEY,
-                DEFAULT_APPLICATION_SOURCE_DIRECTORY));
+        String pathString = settings.getProperty(APPLICATION_SOURCE_DIRECTORY_CONFIG_KEY,
+                DEFAULT_APPLICATION_SOURCE_DIRECTORY);
+        if (sourceFolderContext != null){
+            pathString = PathHelper.endWithFileSeparator(sourceFolderContext) + pathString;
+            return StringHelper.adjustPathString(pathString);
+        }
+        return StringHelper.adjustPathString(pathString);
+    }
+
+    public static String getCopyBookSourceDirectoryPathString() {
+        String pathString = settings.getProperty(COPY_SOURCE_DIRECTORY_CONFIG_KEY,
+                DEFAULT_COPY_SOURCE_DIRECTORY);
+        if (sourceFolderContext != null){
+            pathString = PathHelper.endWithFileSeparator(sourceFolderContext) + pathString;
+            return StringHelper.adjustPathString(pathString);
+        }
+        return StringHelper.adjustPathString(pathString);
+    }
+
+    public static String getTestSourceDirectoryPathString() {
+        String pathString = settings.getProperty(TESTSUITE_DIRECTORY_CONFIG_KEY,
+                DEFAULT_TESTSUITE_DIRECTORY);
+        if (sourceFolderContext != null){
+            pathString = PathHelper.endWithFileSeparator(sourceFolderContext) + pathString;
+            return StringHelper.adjustPathString(pathString);
+        }
+        return StringHelper.adjustPathString(pathString);
     }
 
     public static List<String> getApplicationFilenameSuffixes() {

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -24,7 +24,8 @@ public final class Constants {
     public static final String COBOLCHECK_COPYBOOK_DIRECTORY = COBOLCHECK_PACKAGE_PATH + "/copybooks/";
 
     //Command line options
-    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:g:a:e:vh --long config-file:,log-level:,programs:,tests:,generated-tests:,all-tests:,error-log:,version,help";
+    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:g:a:e:s:vh " +
+            "--long config-file:,log-level:,programs:,tests:,generated-tests:,all-tests:,error-log:,source-context:,version,help";
 
     // Frequently-used string values
     public static final String EMPTY_STRING = "";

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Initializer.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Initializer.java
@@ -44,7 +44,7 @@ public class Initializer {
 
         argumentController.loadSettingsFromArguments();
         String programNames = argumentController.getKeyValue(Constants.PROGRAMS_OPTION);
-        statusController.setSourceProgramNames(programNames.split(Constants.COLON));
+        statusController.setSourceProgramNames(programNames.split("\\|"));
         statusController.setTestFileNames(argumentController.getKeyValue(Constants.TESTS_OPTION));
     }
 

--- a/src/test/java/org/openmainframeproject/cobolcheck/ArgumentHandlerTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/ArgumentHandlerTest.java
@@ -87,7 +87,7 @@ public class ArgumentHandlerTest {
     public void it_handles_option_p_followed_by_two_full_program_names() {
         String expected = "src" + Constants.FILE_SEPARATOR + "main" + Constants.FILE_SEPARATOR
                 + "cobol" + Constants.FILE_SEPARATOR + "PROG1"
-                + Constants.COLON
+                + "|"
                 + "src" + Constants.FILE_SEPARATOR + "main" + Constants.FILE_SEPARATOR
                 + "cobol" + Constants.FILE_SEPARATOR + "PROG2";
         ArgumentHandler argumentHandler = new ArgumentHandler(new String[] { "-p", "PROG1", "PROG2", "-l", "err" },
@@ -100,7 +100,7 @@ public class ArgumentHandlerTest {
     public void it_handles_option_programs_followed_by_two_full_program_names() {
         String expected = "src" + Constants.FILE_SEPARATOR + "main" + Constants.FILE_SEPARATOR
                 + "cobol" + Constants.FILE_SEPARATOR + "PROG1"
-                + Constants.COLON
+                + "|"
                 + "src" + Constants.FILE_SEPARATOR + "main" + Constants.FILE_SEPARATOR
                 + "cobol" + Constants.FILE_SEPARATOR + "PROG2";
         ArgumentHandler argumentHandler = new ArgumentHandler(new String[] { "--programs", "PROG1", "PROG2", "-l", "err" },

--- a/src/test/java/org/openmainframeproject/cobolcheck/CopybookExpanderIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/CopybookExpanderIT.java
@@ -13,6 +13,7 @@ import org.openmainframeproject.cobolcheck.services.Config;
 import org.openmainframeproject.cobolcheck.services.Constants;
 import org.openmainframeproject.cobolcheck.services.StringHelper;
 import org.openmainframeproject.cobolcheck.services.StringTuple;
+import org.openmainframeproject.cobolcheck.services.filehelpers.PathHelper;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,7 +38,7 @@ public class CopybookExpanderIT {
     @BeforeAll
     public static void oneTimeSetup() {
         Config.load("testconfig.properties");
-        pathToTestCobolCopybooks = getPathFor("application.copybook.directory", "src/main/cobol/copy");
+        pathToTestCobolCopybooks = PathHelper.endWithFileSeparator(Config.getCopyBookSourceDirectoryPathString());
     }
 
     @BeforeEach
@@ -130,17 +131,6 @@ public class CopybookExpanderIT {
         String s = new String(readAllBytes(f.toPath()));
         String[] lines = s.split("\n");
         return removeTrailingSpacesFromLines(Arrays.asList(lines));
-    }
-
-    private static String getPathFor(String configPropertyName, String defaultValue) {
-        StringBuilder directoryName = new StringBuilder();
-        directoryName.append(new File("./").getAbsolutePath());
-        directoryName.append(Constants.FILE_SEPARATOR);
-        directoryName.append(Config.getString(configPropertyName, "src/main/cobol/copy"));
-        if (!directoryName.toString().endsWith(Constants.FILE_SEPARATOR)) {
-            directoryName.append(Constants.FILE_SEPARATOR);
-        }
-        return directoryName.toString();
     }
 
     //Needed as 'expected' and 'actual' have different trailing spaces, even

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestResultsFileOutputIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestResultsFileOutputIT.java
@@ -24,7 +24,7 @@ public class TestResultsFileOutputIT {
 
         launcherController = new LauncherController();
 
-        String testSuiteDirectoryPath = Config.getTestSuiteDirectoryPathString();
+        String testSuiteDirectoryPath = Config.getTestSourceDirectoryPathString();
     }
 
     @Test

--- a/vs code extension/CHANGELOG.md
+++ b/vs code extension/CHANGELOG.md
@@ -11,3 +11,11 @@ All notable changes to the "cobol-unit-test" extension will be documented in thi
 - Updated Readme, as not all information was correct
 - Added icon
 - Cleaned up some unnecessary files
+
+## [0.2.0] 04.03.2022
+
+- Integrated Cobol Check into extension
+- Added Cobol Check view
+- Added command for running Cobol Check
+- Added command for configuring Cobol Check
+- Added command for resetting the configurations

--- a/vs code extension/Cobol-check/cobolcheck
+++ b/vs code extension/Cobol-check/cobolcheck
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -jar bin/cobol-check-0.1.0.jar $@

--- a/vs code extension/Cobol-check/cobolcheck.cmd
+++ b/vs code extension/Cobol-check/cobolcheck.cmd
@@ -1,0 +1,2 @@
+@echo off
+java -jar bin\cobol-check-0.1.0.jar %*

--- a/vs code extension/Cobol-check/config.properties
+++ b/vs code extension/Cobol-check/config.properties
@@ -1,0 +1,183 @@
+# Configuration settings for Cobol Check
+
+#---------------------------------------------------------------------------------------------------------------------
+# This configuration - echoed to console when Cobol Check is executed, for information only.
+#---------------------------------------------------------------------------------------------------------------------
+config.loaded = production
+
+#---------------------------------------------------------------------------------------------------------------------
+# Prefix for field names and paragraph names in the test management code that cobol-check
+# inserts into programs to be tested. The default is "UT-". If this conflicts with names
+# in the programs to be tested, you can override it with a value you specify here.
+# The value must be 3 characters or less. Cannot be empty.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.prefix = UT-
+
+#---------------------------------------------------------------------------------------------------------------------
+# Tags written in the generated test code in the form of a comment, when a code injection starts and ends.
+# Default is null, which will prevent the tags from appearing. Any other value will appear as comments
+# surrounding the injected code.
+# Examples:
+# cobolcheck.injectedCodeTag.start = ###INJECT START###
+# cobolcheck.injectedCodeTag.end = ###INJECT END###
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.injectedCodeTag.start = null
+cobolcheck.injectedCodeTag.end = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# A tag written at the start of entities stubbed by default. Recommended value-length <= 4.
+# Note: The tag will appear only when cobolcheck stubs lines by default.
+# This is the case for CALLs and batch file IO verbs.
+# Default is null, which will prevent the tag from appearing.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.stub.comment.tag = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines if cobolcheck should generate code, such that decimal point is comma.
+# The default is "false". The value should be set to "true" if the compiler is set to
+# read decimal points as commas. If the cobol source program sets DECIMAL-POINT IS COMMA,
+# this configuration will be overwritten.
+# Example: 1,385,481.00 (decimalPointIsComma = false)
+# Example: 1.385.481,00 (decimalPointIsComma = true)
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.decimalPointIsComma = false
+
+#---------------------------------------------------------------------------------------------------------------------
+# If the source program contains rules as the first line follwed by CBL, the given value will be appended
+# to this.
+# If no CBL is found in source, it will be added along with the given value
+# default is null, which will make no changes.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.append.rules = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# Path for the generated Cobol test code
+# Default: ./
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.program.path = Cobol-check
+
+#---------------------------------------------------------------------------------------------------------------------
+# Suffix to append to the name of each program under test to produce the name of the corresponding
+# test program that contains the merged test code.
+# Example: For program ABCXYZ4, if suffix is T.CBL then the test program name will be ABCXYZ4T.CBL.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.program.name = CC##99.CBL
+
+#---------------------------------------------------------------------------------------------------------------------
+# Path for the generated testsuite parse error log
+# Default: ./
+#---------------------------------------------------------------------------------------------------------------------
+testsuite.parser.error.log.path = Cobol-check
+
+#---------------------------------------------------------------------------------------------------------------------
+# Name of the generated testsuite parse error log file - with extension
+# Default: ParserErrorLog.txt
+#---------------------------------------------------------------------------------------------------------------------
+testsuite.parser.error.log.name = ParserErrorLog.txt
+
+#---------------------------------------------------------------------------------------------------------------------
+# The charset that cobolcheck will use when reading- and writing to files.
+# See https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html, for a list of
+# valid values.
+# Default value for each OS is <default>, which will use the default encoding for the OS.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.file.encoding.linux = default
+cobolcheck.file.encoding.macosx = default
+cobolcheck.file.encoding.windows = default
+cobolcheck.file.encoding.zos = default
+cobolcheck.file.encoding.unix = default
+
+#---------------------------------------------------------------------------------------------------------------------
+# Sets permissions for all files generated by Cobol Check, for all users.
+# If read, write and execute permissions are set, all users can perform said actions on all files
+# that Cobol Check generates.
+# Value can be any permutation of the letters: 'rwx' (read, write, execute) or none - meaning no permissions.
+# Default value: rx
+#---------------------------------------------------------------------------------------------------------------------
+generated.files.permission.all = rx
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines if Cobol Check should run the generated test program.
+# Default is true.
+# If set to false, Cobol Check will generate the code, but not run it. If more than one program
+# is given as a command line option, the generated test file will be overwritten. Thus if set to false,
+# only one program should be given at a time.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.run = true
+
+#---------------------------------------------------------------------------------------------------------------------
+# These settings are to locate the application code under test in *your* Cobol project directory tree.
+# Can be absolute path or relative to project root.
+#---------------------------------------------------------------------------------------------------------------------
+application.source.directory = src/main/cobol
+application.copybook.directory = src/main/cobol/copy
+
+#---------------------------------------------------------------------------------------------------------------------
+# Location of test suite input file(s). This can also be passed on command-line option --test-suite-path.
+#---------------------------------------------------------------------------------------------------------------------
+test.suite.directory = src/test/cobol
+
+#---------------------------------------------------------------------------------------------------------------------
+# Location of test output. File extension is determined by a given format.
+#---------------------------------------------------------------------------------------------------------------------
+test.results.file = Cobol-check/output/testResults
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines the format of the test results written to the output file.
+# Supported formats: txt, xml.
+#---------------------------------------------------------------------------------------------------------------------
+test.results.format = txt
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines the format style of the test results written to the output file.
+# The style controls the hierarchy and structure of data and naming of the 'object' that is written
+# in a given format. Format: txt and style: directOutput are exclusive. txt cannot use any other style
+# than directOutput, and directOutput cannot be used with any other format than txt.
+# Other formats and styles can be used interchangeably.
+# Supported styles: directOutput, JUnit
+#---------------------------------------------------------------------------------------------------------------------
+test.results.format.style = directOutput
+
+#---------------------------------------------------------------------------------------------------------------------
+# If application source filenames have a suffix, specify it here without the period or dot.
+#---------------------------------------------------------------------------------------------------------------------
+application.source.filename.suffix = CBL,cbl,COB,cob
+
+#---------------------------------------------------------------------------------------------------------------------
+# If application copybook filenames have a suffix, specify it here without the period or dot
+# e.g. application.copybook.filename.suffix = CBL
+#---------------------------------------------------------------------------------------------------------------------
+application.copybook.filename.suffix = CBL,cbl,COB,cob
+
+#---------------------------------------------------------------------------------------------------------------------
+# Optional override of system default Locale for log messages and exception messages.
+#---------------------------------------------------------------------------------------------------------------------
+#locale.language = ja
+#locale.country =
+#locale.variant =
+
+#---------------------------------------------------------------------------------------------------------------------
+# Cobol Check concatenates multiple test suite input files into a single file for the Generator.
+# This is the relative or absolute path of the concatenated file. If not specified, the default
+# is "./ALLTESTS" relative to the directory in which Cobol Check was started.
+#---------------------------------------------------------------------------------------------------------------------
+concatenated.test.suites = Cobol-check/ALLTESTS
+
+#---------------------------------------------------------------------------------------------------------------------
+# Shell scripts and JCL files for executing your test suites.
+# Cobol Check will invoke one of these after creating the copy of the program under test that contains
+# test code generated from your test suites.
+# Unix and Mac OS X are both treated as unix. Most unices can run the linux script.
+# Unix is the default.
+# You can write custom scripts/JCL for your environment, for instance if you are using a different Cobol compiler.
+# The first element in these names reflects the first few characters returned by Java's System.getProperty("os.name").
+# Cobol Check will select one of these entries based on which platform it thinks it's running on.
+#---------------------------------------------------------------------------------------------------------------------
+
+cobolcheck.script.directory = Cobol-check/scripts
+linux.process = linux_gnucobol_run_tests
+osx.process = linux_gnucobol_run_tests
+freebsd.process = linux_gnucobol_run_tests
+windows.process = windows_gnucobol_run_tests.cmd
+zos.process =
+unix.process = linux_gnucobol_run_tests

--- a/vs code extension/Cobol-check/default.properties
+++ b/vs code extension/Cobol-check/default.properties
@@ -1,0 +1,183 @@
+# Configuration settings for Cobol Check
+
+#---------------------------------------------------------------------------------------------------------------------
+# This configuration - echoed to console when Cobol Check is executed, for information only.
+#---------------------------------------------------------------------------------------------------------------------
+config.loaded = production
+
+#---------------------------------------------------------------------------------------------------------------------
+# Prefix for field names and paragraph names in the test management code that cobol-check
+# inserts into programs to be tested. The default is "UT-". If this conflicts with names
+# in the programs to be tested, you can override it with a value you specify here.
+# The value must be 3 characters or less. Cannot be empty.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.prefix = UT-
+
+#---------------------------------------------------------------------------------------------------------------------
+# Tags written in the generated test code in the form of a comment, when a code injection starts and ends.
+# Default is null, which will prevent the tags from appearing. Any other value will appear as comments
+# surrounding the injected code.
+# Examples:
+# cobolcheck.injectedCodeTag.start = ###INJECT START###
+# cobolcheck.injectedCodeTag.end = ###INJECT END###
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.injectedCodeTag.start = null
+cobolcheck.injectedCodeTag.end = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# A tag written at the start of entities stubbed by default. Recommended value-length <= 4.
+# Note: The tag will appear only when cobolcheck stubs lines by default.
+# This is the case for CALLs and batch file IO verbs.
+# Default is null, which will prevent the tag from appearing.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.stub.comment.tag = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines if cobolcheck should generate code, such that decimal point is comma.
+# The default is "false". The value should be set to "true" if the compiler is set to
+# read decimal points as commas. If the cobol source program sets DECIMAL-POINT IS COMMA,
+# this configuration will be overwritten.
+# Example: 1,385,481.00 (decimalPointIsComma = false)
+# Example: 1.385.481,00 (decimalPointIsComma = true)
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.decimalPointIsComma = false
+
+#---------------------------------------------------------------------------------------------------------------------
+# If the source program contains rules as the first line follwed by CBL, the given value will be appended
+# to this.
+# If no CBL is found in source, it will be added along with the given value
+# default is null, which will make no changes.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.append.rules = null
+
+#---------------------------------------------------------------------------------------------------------------------
+# Path for the generated Cobol test code
+# Default: ./
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.program.path = Cobol-check
+
+#---------------------------------------------------------------------------------------------------------------------
+# Suffix to append to the name of each program under test to produce the name of the corresponding
+# test program that contains the merged test code.
+# Example: For program ABCXYZ4, if suffix is T.CBL then the test program name will be ABCXYZ4T.CBL.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.program.name = CC##99.CBL
+
+#---------------------------------------------------------------------------------------------------------------------
+# Path for the generated testsuite parse error log
+# Default: ./
+#---------------------------------------------------------------------------------------------------------------------
+testsuite.parser.error.log.path = Cobol-check
+
+#---------------------------------------------------------------------------------------------------------------------
+# Name of the generated testsuite parse error log file - with extension
+# Default: ParserErrorLog.txt
+#---------------------------------------------------------------------------------------------------------------------
+testsuite.parser.error.log.name = ParserErrorLog.txt
+
+#---------------------------------------------------------------------------------------------------------------------
+# The charset that cobolcheck will use when reading- and writing to files.
+# See https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html, for a list of
+# valid values.
+# Default value for each OS is <default>, which will use the default encoding for the OS.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.file.encoding.linux = default
+cobolcheck.file.encoding.macosx = default
+cobolcheck.file.encoding.windows = default
+cobolcheck.file.encoding.zos = default
+cobolcheck.file.encoding.unix = default
+
+#---------------------------------------------------------------------------------------------------------------------
+# Sets permissions for all files generated by Cobol Check, for all users.
+# If read, write and execute permissions are set, all users can perform said actions on all files
+# that Cobol Check generates.
+# Value can be any permutation of the letters: 'rwx' (read, write, execute) or none - meaning no permissions.
+# Default value: rx
+#---------------------------------------------------------------------------------------------------------------------
+generated.files.permission.all = rx
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines if Cobol Check should run the generated test program.
+# Default is true.
+# If set to false, Cobol Check will generate the code, but not run it. If more than one program
+# is given as a command line option, the generated test file will be overwritten. Thus if set to false,
+# only one program should be given at a time.
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.test.run = true
+
+#---------------------------------------------------------------------------------------------------------------------
+# These settings are to locate the application code under test in *your* Cobol project directory tree.
+# Can be absolute path or relative to project root.
+#---------------------------------------------------------------------------------------------------------------------
+application.source.directory = src/main/cobol
+application.copybook.directory = src/main/cobol/copy
+
+#---------------------------------------------------------------------------------------------------------------------
+# Location of test suite input file(s). This can also be passed on command-line option --test-suite-path.
+#---------------------------------------------------------------------------------------------------------------------
+test.suite.directory = src/test/cobol
+
+#---------------------------------------------------------------------------------------------------------------------
+# Location of test output. File extension is determined by a given format.
+#---------------------------------------------------------------------------------------------------------------------
+test.results.file = Cobol-check/output/testResults
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines the format of the test results written to the output file.
+# Supported formats: txt, xml.
+#---------------------------------------------------------------------------------------------------------------------
+test.results.format = txt
+
+#---------------------------------------------------------------------------------------------------------------------
+# Determines the format style of the test results written to the output file.
+# The style controls the hierarchy and structure of data and naming of the 'object' that is written
+# in a given format. Format: txt and style: directOutput are exclusive. txt cannot use any other style
+# than directOutput, and directOutput cannot be used with any other format than txt.
+# Other formats and styles can be used interchangeably.
+# Supported styles: directOutput, JUnit
+#---------------------------------------------------------------------------------------------------------------------
+test.results.format.style = directOutput
+
+#---------------------------------------------------------------------------------------------------------------------
+# If application source filenames have a suffix, specify it here without the period or dot.
+#---------------------------------------------------------------------------------------------------------------------
+application.source.filename.suffix = CBL,cbl,COB,cob
+
+#---------------------------------------------------------------------------------------------------------------------
+# If application copybook filenames have a suffix, specify it here without the period or dot
+# e.g. application.copybook.filename.suffix = CBL
+#---------------------------------------------------------------------------------------------------------------------
+application.copybook.filename.suffix = CBL,cbl,COB,cob
+
+#---------------------------------------------------------------------------------------------------------------------
+# Optional override of system default Locale for log messages and exception messages.
+#---------------------------------------------------------------------------------------------------------------------
+#locale.language = ja
+#locale.country =
+#locale.variant =
+
+#---------------------------------------------------------------------------------------------------------------------
+# Cobol Check concatenates multiple test suite input files into a single file for the Generator.
+# This is the relative or absolute path of the concatenated file. If not specified, the default
+# is "./ALLTESTS" relative to the directory in which Cobol Check was started.
+#---------------------------------------------------------------------------------------------------------------------
+concatenated.test.suites = Cobol-check/ALLTESTS
+
+#---------------------------------------------------------------------------------------------------------------------
+# Shell scripts and JCL files for executing your test suites.
+# Cobol Check will invoke one of these after creating the copy of the program under test that contains
+# test code generated from your test suites.
+# Unix and Mac OS X are both treated as unix. Most unices can run the linux script.
+# Unix is the default.
+# You can write custom scripts/JCL for your environment, for instance if you are using a different Cobol compiler.
+# The first element in these names reflects the first few characters returned by Java's System.getProperty("os.name").
+# Cobol Check will select one of these entries based on which platform it thinks it's running on.
+#---------------------------------------------------------------------------------------------------------------------
+
+cobolcheck.script.directory = Cobol-check/scripts
+linux.process = linux_gnucobol_run_tests
+osx.process = linux_gnucobol_run_tests
+freebsd.process = linux_gnucobol_run_tests
+windows.process = windows_gnucobol_run_tests.cmd
+zos.process =
+unix.process = linux_gnucobol_run_tests

--- a/vs code extension/Cobol-check/scripts/linux_gnucobol_run_tests
+++ b/vs code extension/Cobol-check/scripts/linux_gnucobol_run_tests
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Linux - compile and execute a test Cobol program
+#
+# Assumptions:
+#
+# GnuCOBOL 2.2 or later is installed and on the path. Its executable or alias or symlink is named "cobc".
+
+cobc -x $@
+name=$(echo "$1" | cut -f 1 -d '.')
+"${name}"

--- a/vs code extension/Cobol-check/scripts/windows_gnucobol_run_tests.cmd
+++ b/vs code extension/Cobol-check/scripts/windows_gnucobol_run_tests.cmd
@@ -1,0 +1,8 @@
+@echo off
+rem Windows - compile and execute a test Cobol program
+rem
+rem  Assumptions:
+rem
+rem GnuCOBOL 3.+ is installed and on the path. Its executable or alias or symlink is named "cobc".
+
+cobc -x %1 && %~n1

--- a/vs code extension/Cobol-check/src/main/cobol/ALPHA.CBL
+++ b/vs code extension/Cobol-check/src/main/cobol/ALPHA.CBL
@@ -1,0 +1,26 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.  ALPHA.
+      *****************************************************************
+      * Program to exercise EXPECT statements.
+      *****************************************************************       
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  FILLER.
+           05  WS-FIELD-1           PIC X(80).
+           05  ws-Field-2           PIC X(80).
+           05  ws-table-1.
+               10  ws-table-1-entry occurs 5
+                       indexed by table-1-ix.
+                   15  ws-thing-1   pic x(5).
+                   15  ws-thing-2   pic x(5).
+           05  ws-table-2.
+               10  ws-table-2-entry occurs 5
+                       indexed by table-2-ix.
+                   15  ws-thing-3   pic x(5).
+                   15  ws-thing-4   pic x(5).
+           05  ws-display-numeric   pic 999.
+       PROCEDURE DIVISION.
+           GOBACK.

--- a/vs code extension/Cobol-check/src/main/cobol/NUMBERS.CBL
+++ b/vs code extension/Cobol-check/src/main/cobol/NUMBERS.CBL
@@ -1,0 +1,18 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID.  NUMBERS.
+      *****************************************************************
+      * Program to exercise symbolic relations like ">=" and "!=".
+      *****************************************************************       
+       ENVIRONMENT DIVISION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  FILLER.
+           05  ws-field-1           PIC S9(11)V9(07) COMP-3.
+           05  WS-FIELD-2           PIC S9(11)V9(07) comp-3.
+           05  ws-field-3           pic s9(16) comp.
+           05  ws-field-4           pic s9(16) comp-4.
+           05  ws-display-field     pic s9(5)v99.
+       PROCEDURE DIVISION.
+           GOBACK.

--- a/vs code extension/Cobol-check/src/test/cobol/ALPHA/AlphaExpectationsTest.cut
+++ b/vs code extension/Cobol-check/src/test/cobol/ALPHA/AlphaExpectationsTest.cut
@@ -1,0 +1,61 @@
+           TestSuite "Tests of alphanumeric expectations"
+
+           TestCase "Equality with an alphanumeric literal using TO BE"
+           move "value1" to ws-field-1
+           Expect ws-field-1 to be "value1"
+
+           TestCase "Equality with an alphanumeric literal using TO EQUAL"
+           move "value2" to ws-field-1
+           Expect ws-field-1 to equal "value2"
+
+           TestCase "Equality with an alphanumeric literal using '='"
+           move "value3" to ws-field-1
+           Expect ws-field-1 = "value3"
+
+           TestCase "Equality with an alphanumeric literal and reference modification"
+           move "Hello, World!" to ws-field-2
+           Expect ws-field-2(8:5) to be "World"
+
+           TestCase "Non-equality with an alphanumeric literal using TO BE"
+           move "value4" to ws-field-1
+           Expect ws-field-1 not to be "value1"
+
+           TestCase "Non-equality with an alphanumeric literal using TO EQUAL"
+           move "value5" to ws-field-1
+           Expect ws-field-1 not to equal "value1"
+
+           TestCase "Non-equality with an alphanumeric literal using '!='"
+           move "value6" to ws-field-1
+           Expect ws-field-1 != "value1"
+
+           TestCase "Non-equality with an alphanumeric literal and reference modification"
+           move "Hello, World!" to ws-field-2
+           Expect ws-field-2(8:6) not to be "World"
+
+           TestCase "Greater-than sign with an alphanumeric literal"
+           move "Beta" to ws-field-1
+           move "Alpha" to ws-field-2
+           Expect ws-field-1 > ws-field-2
+
+           TestCase "Less-than sign with an alphanumeric literal"
+           move "Beta" to ws-field-1
+           move "Alpha" to ws-field-2
+           Expect ws-field-2 < ws-field-1
+
+           TestCase "Not greater-than sign with an alphanumeric literal"
+           move "Beta" to ws-field-1
+           move "Alpha" to ws-field-2
+           Expect ws-field-2 not > ws-field-1
+
+           TestCase "Not less-than sign with an alphanumeric literal"
+           move "Beta" to ws-field-1
+           move "Alpha" to ws-field-2
+           Expect ws-field-1 not < ws-field-2
+
+           TestCase "Display numeric"
+           move 6 to ws-display-numeric
+           expect ws-display-numeric to be 6
+
+
+
+

--- a/vs code extension/Cobol-check/src/test/cobol/NUMBERS/SymbolicRelationsTest.cut
+++ b/vs code extension/Cobol-check/src/test/cobol/NUMBERS/SymbolicRelationsTest.cut
@@ -1,0 +1,246 @@
+           TestSuite "Verify Cobol Check handles numeric relations properly"
+
+           TestCase "Equal sign with literal compare"
+           Move 25.74 to WS-FIELD-1
+           Expect WS-FIELD-1 = 25.74
+
+           TestCase "Equal sign with literal compare (should fail)"
+           Move 25.74 to WS-FIELD-1
+           Expect WS-FIELD-1 = 25.75
+
+* comment 1
+
+           TestCase "Not equal sign with literal compare"
+           Move 25.74 to WS-FIELD-1
+           Expect WS-FIELD-1 NOT = 25.75
+
+           *comment 2
+
+           TestCase "Not equal sign with literal compare (should fail)"
+           Move 25.74 to WS-FIELD-1
+           Expect WS-FIELD-1 not = 25.74
+
+           TestCase "Not-equal sign with literal compare"
+           Move 13.6 to WS-FIELD-1
+           Expect WS-FIELD-1 != 25.74
+
+           TestCase "Not-equal sign with literal compare (should fail)"
+           Move 13.6 to WS-FIELD-1
+           Expect WS-FIELD-1 != 13.6
+
+           TestCase "Not not-equal sign with literal compare"
+           Move 13.6 to WS-FIELD-1
+           Expect WS-FIELD-1 NOT != 13.6
+
+           TestCase "Not not-equal sign with literal compare (should fail)"
+           Move 13.7 to WS-FIELD-1
+           Expect WS-FIELD-1 not != 13.6
+
+           TestCase "Equal sign with ield compare"
+           Move 25.74 to WS-FIELD-1
+           Move 25.74 to WS-FIELD-2
+           Expect WS-FIELD-1 = WS-FIELD-2
+
+           TestCase "Equal sign with field compare (should fail)"
+           Move 25.74 to WS-FIELD-1
+           Move 25.75 to WS-FIELD-2
+           Expect WS-FIELD-1 = WS-FIELD-2
+
+           TestCase "Not equal sign with field compare"
+           Move 25.74 to WS-FIELD-1
+           Move 25.75 to WS-FIELD-2
+           Expect WS-FIELD-1 not = WS-FIELD-2
+
+           TestCase "Not equal sign with field compare (should fail)"
+           Move 25.74 to WS-FIELD-1
+           Move 25.74 to WS-FIELD-2
+           Expect WS-FIELD-1 not = WS-FIELD-2
+
+           TestCase "Not-equal sign with field compare"
+           Move 25.74 to WS-FIELD-1
+           Move 25.75 to WS-FIELD-2
+           Expect WS-FIELD-1 != WS-FIELD-2
+
+           TestCase "Not-equal sign with field compare (should fail)"
+           Move 25.74 to WS-FIELD-1
+           Move 25.74 to WS-FIELD-2
+           Expect WS-FIELD-1 != WS-FIELD-2
+
+           TestCase "Not not-equal sign with field compare"
+           Move 25.74 to WS-FIELD-1
+           Move 25.74 to WS-FIELD-2
+           Expect WS-FIELD-1 NOT != WS-FIELD-2
+
+           TestCase "Not not-equal sign with field compare (should fail)"
+           Move 25.75 to WS-FIELD-1
+           Move 25.74 to WS-FIELD-2
+           Expect WS-FIELD-1 not != WS-FIELD-2
+
+           TestCase "Less-than sign with literal compare"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 < 18.068
+
+           TestCase "Less-than sign with literal compare (should fail)"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 < 18.066
+
+           TestCase "Not less-than sign with literal compare"
+           Move 18.068 to WS-FIELD-1
+           Expect WS-FIELD-1 NOT < 18.068
+
+           TestCase "Not less-than sign with literal compare (should fail)"
+           Move 18.066 to WS-FIELD-1
+           Expect WS-FIELD-1 Not < 18.067
+
+           TestCase "Less-than sign with field compare"
+           Move 416.071 to WS-FIELD-1
+           Move 416.072 to WS-FIELD-2
+           Expect WS-FIELD-1 < WS-FIELD-2
+
+           TestCase "Less-than sign with field compare (should fail)"
+           Move 416.072 to WS-FIELD-1
+           Move 416.072 to WS-FIELD-2
+           Expect WS-FIELD-1  < WS-FIELD-2
+
+           TestCase "Not less-than sign with field compare"
+           Move 416.072 to WS-FIELD-1
+           Move 416.071 to WS-FIELD-2
+           Expect WS-FIELD-1 not < WS-FIELD-2
+
+           TestCase "Not less-than sign with field compare (should fail)"
+           Move 416.071 to WS-FIELD-1
+           Move 416.072 to WS-FIELD-2
+           Expect WS-FIELD-1 not < WS-FIELD-2
+
+           TestCase "Greater-than sign with literal compare"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 > 17.01
+
+           TestCase "Greater-than sign with literal compare (should fail)"
+           Move 9.805 to WS-FIELD-1
+           Expect WS-FIELD-1 > 10
+
+           TestCase "Not greater-than sign with literal compare"
+           move 107.701 to ws-field-1
+           move 107.701 to ws-field-2
+           expect ws-field-1 not > ws-field-2
+
+           TestCase "Not greater-than sign with literal compare (should fail)"
+           move 107.702 to ws-field-1
+           move 107.701 to ws-field-2
+           expect ws-field-1 not > ws-field-2
+
+           TestCase "Greater-than sign with field compare"
+           Move 1766.03145 to WS-FIELD-1
+           Move 1766.03144 to WS-FIELD-2
+           Expect WS-FIELD-1 > WS-FIELD-2
+
+           TestCase "Greater-than sign with field compare (should fail)"
+           Move 1766.03143 to WS-FIELD-1
+           Move 1766.03144 to WS-FIELD-2
+           Expect WS-FIELD-1 > WS-FIELD-2
+
+           TestCase "Not greater-than sign with field to field compare"
+           Move 1766.03144 to WS-FIELD-1
+           Move 1766.03144 to WS-FIELD-2
+           Expect WS-FIELD-1 Not > WS-FIELD-2
+
+           TestCase "Not greater-than sign with field compare (should fail)"
+           Move 1766.03145 to WS-FIELD-1
+           Move 1766.03144 to WS-FIELD-2
+           Expect WS-FIELD-1 NOT > WS-FIELD-2
+
+           TestCase "Greater-than-or-equal-to sign with literal compare when greater"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 >= 18.066
+
+           TestCase "Greater-than-or-equal-to sign with literal compare when equal"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 >= 18.067
+
+           TestCase "Greater-than-or-equal-to sign with literal compare (should fail)"
+           Move 9.805 to WS-FIELD-1
+           Expect WS-FIELD-1 >= 10
+
+           TestCase "Not greater-than-or-equal-to sign with literal compare when less"
+           Move 18.066 to WS-FIELD-1
+           Expect WS-FIELD-1 not >= 18.067
+
+           TestCase "Not greater-than-or-equal-to sign with literal compare when equal (should fail)"
+           Move 18.067 to WS-FIELD-1
+           Expect WS-FIELD-1 not >= 18.067
+
+           TestCase "Greater-than-or-equal-to sign with literal compare when greater (should fail)"
+           Move 13.45 to WS-FIELD-1
+           Expect WS-FIELD-1 not >= 13.44
+
+           TestCase "Greater-than-or-equal-to-sign with field compare when equal"
+           move 475.062 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 >= ws-field-2
+
+           TestCase "Greater-than-or-equal-to-sign with field compare when greater"
+           move 475.063 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 >= ws-field-2
+
+           TestCase "Greater-than-or-equal-to-sign with field compare when less (should fail)"
+           move 475.061 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 >= ws-field-2
+
+           TestCase "Not greater-than-or-equal-to-sign with field compare when less"
+           move 475.062 to ws-field-1
+           move 475.063 to ws-field-2
+           expect ws-field-1 not >= ws-field-2
+
+           TestCase "Not greater-than-or-equal-to-sign with field compare when equal (should fail)"
+           move 475.062 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 not >= ws-field-2
+
+           TestCase "Not greater-than-or-equal-to-sign with field compare when greater (should fail)"
+           move 475.063 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 not >= ws-field-2
+
+           TestCase "Less-than-or-equal-to-sign with field compare when equal"
+           move 475.062 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 <= ws-field-2
+
+           TestCase "Less-than-or-equal-to-sign with field compare when less"
+           move 475.062 to ws-field-1
+           move 475.063 to ws-field-2
+           expect ws-field-1 <= ws-field-2
+
+           TestCase "Less-than-or-equal-to-sign with field compare when greater (should fail)"
+           move 475.063 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 <= ws-field-2
+
+           TestCase "Not less-than-or-equal-to-sign with field compare when greater"
+           move 475.063 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 not <= ws-field-2
+
+           TestCase "Not greater-than-or-equal-to-sign with field compare when equal (should fail)"
+           move 475.062 to ws-field-1
+           move 475.062 to ws-field-2
+           expect ws-field-1 not <= ws-field-2
+
+           TestCase "Not greater-than-or-equal-to-sign with field compare when less (should fail)"
+           move 475.062 to ws-field-1
+           move 475.063 to ws-field-2
+           expect ws-field-1 not <= ws-field-2
+
+           TestCase "Display Numeric field equals literal"
+           move 123.45 to ws-display-field
+           expect ws-display-field to be 123.45
+
+
+
+
+
+
+

--- a/vs code extension/README.md
+++ b/vs code extension/README.md
@@ -2,14 +2,18 @@
 
 Cobol Check provides fine-grained unit testing/checking for Cobol at the same conceptual level of detail as unit testing frameworks for other languages, such as Python, Ruby, C#, and Java.
 
-This package delivers the functionality of Cobol Check(not yet implemented) along with the Cobol unit test language(CUT). This is the language used to write unit tests for Cobol Check.
+This package delivers the functionality of Cobol Check along with the Cobol unit test language(CUT). This is the language used to write unit tests for Cobol Check.
 
-Currently the extension has the following features pertaining the the CUT langauge:
-1. Syntax highlighting
-2. Auto completion using snippets
-3. Error reporting of mismatched delimiters
+Currently the extension has the following features:
+1. Running tests based on current open file - Press button or run command [CobolCheck: Run]
+2. Configuring Cobol Check - Command [CobolCheck: Configure property] (Configuration info: https://github.com/openmainframeproject/cobol-check/wiki/Configuration-Settings)
+3. Resetting configuration to default values - Command [CobolCheck: Reset configurations to default]
+4. Syntax highlighting
+5. Auto completion using snippets
+6. Error reporting of mismatched delimiters
 
 ## Requirements
+Cobol Check requires a global installation of GnuCOBOL.
 
 The cobol-unit-test-syntax package references the COBOL grammar, defined in IBM Z Open Editor, for inline COBOL.
 Additionally, tab behavior is handled by referencing the custom tab function defined in aforementioned extension.

--- a/vs code extension/client/package.json
+++ b/vs code extension/client/package.json
@@ -3,7 +3,7 @@
 	"description": "Cobol-check extension to run cobol unit tests",
 	"author": "Open Mainframe Project",
 	"license": "MIT",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"publisher": "openmainframeproject",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vs code extension/client/src/services/CobolCheckConfiguration.ts
+++ b/vs code extension/client/src/services/CobolCheckConfiguration.ts
@@ -1,0 +1,106 @@
+import * as vscode from 'vscode';
+
+
+export function getConfigurationMap(configurationPath : string, callBack: (configurationMap : Map<string, string>) => any){
+	const fs = require('fs');
+
+	fs.readFile(configurationPath, 'utf8', function(err, data) {
+		if(err) throw err;
+
+		const arr = data.toString().replace(/\r\n/g,'\n').split('\n');
+		var configurations = new Map<string,string>();
+
+		for(let line of arr) {
+			line = line.trim();
+			if (line !== "" && !line.startsWith('#')){
+				let keyValue = line.split('=');
+				if (keyValue.length > 1){
+					let key = keyValue[0].trim();
+					let value = keyValue[1].trim();
+					configurations.set(key, value);
+				}
+			}
+		}
+		callBack(configurations);
+	});
+}
+
+export function setConfiguration(configurationPath : string, key : string, newValue : string){
+	const fs = require('fs');
+
+	fs.readFile(configurationPath, 'utf8', function(err, data) {
+		if(err) throw err;
+
+		const arr = data.toString().replace(/\r\n/g,'\n').split('\n');
+		var newConfigurationText = "";
+		var keyHasBeenFound = false;
+
+		for(let line of arr) {
+			var trimmedLine = line.trim();
+			if (trimmedLine === "" && trimmedLine.startsWith('#')){
+				newConfigurationText += line + '\n';
+				continue;
+			}
+
+			let keyValue = trimmedLine.split('=');
+			if (keyValue.length > 1 && keyValue[0].trim() === key){
+				newConfigurationText += key + ' = ' + newValue;
+				keyHasBeenFound = true;
+			} else{
+				newConfigurationText += line + '\n';
+			}
+		}
+
+		if (!keyHasBeenFound){
+			vscode.window.showErrorMessage('Could not find key: ' + key + ' in config file: ' + configurationPath)
+		}
+		fs.writeFile(configurationPath, newConfigurationText, 'utf8', function (err) {
+			if (err) return console.log(err);
+		 });
+	});
+}
+
+export function resetConfigurations(configurationPath : string, defaultConfigurationPath : string){
+	const fs = require('fs');
+
+	fs.readFile(defaultConfigurationPath, 'utf8', function(err, data) {
+		if(err) throw err;
+
+		const newConfigurationText = data.toString();
+
+		fs.writeFile(configurationPath, newConfigurationText, 'utf8', function (err) {
+			if (err) return console.log(err);
+		 });
+	});
+}
+
+export function getConfigurationValueFor(configurationPath : string, key : string) : Promise <string>{
+	const fs = require('fs');
+
+	return new Promise(async resolve => {
+
+		fs.readFile(configurationPath, 'utf8', function(err, data) {
+			if(err) throw err;
+	
+			const arr = data.toString().replace(/\r\n/g,'\n').split('\n');
+	
+			for(let line of arr) {
+				line = line.trim();
+				if (line !== "" && !line.startsWith('#')){
+					let keyValue = line.split('=');
+					if (keyValue.length > 1){
+						let _key = keyValue[0].trim();
+						let _value = keyValue[1].trim();
+						if (_key === key){
+							resolve(_value);
+							// callBack(_value);
+							// return;
+						}
+					}
+				}
+			}
+			resolve(null);
+		});
+
+	 });
+}

--- a/vs code extension/client/src/services/CobolCheckLauncher.ts
+++ b/vs code extension/client/src/services/CobolCheckLauncher.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+import { integer } from 'vscode-languageclient';
+
+let cobolCheckJar_Windows = '@java -jar Cobol-check\\bin\\cobol-check-0.1.0.jar';
+let cobolCheckJar_Linux_Mac = 'java -jar Cobol-check/bin/cobol-check-0.1.0.jar $@';
+
+const windowsPlatform = 'Windows';
+const macPlatform = 'MacOS';
+const linuxPlatform = 'Linux';
+
+let currentPlatform = getOS();
+
+let lastProgramPath : string = null;
+
+export async function runCobolCheck(commandLineArgs : string) : Promise<string> {
+	return new Promise(async resolve => {
+		// Getting the right command based on platform
+		let executeJarCommand = '';
+		if (currentPlatform === windowsPlatform){
+			executeJarCommand = cobolCheckJar_Windows;
+		}else if (currentPlatform === macPlatform || currentPlatform === linuxPlatform){
+			executeJarCommand = cobolCheckJar_Linux_Mac;
+		} else{
+			vscode.window.showErrorMessage('Only Windows, Mac OS and Linux are supported for running Cobol Check. ' + 
+				'Your platform: ' + currentPlatform + ' is not supported');
+			resolve(null);
+		}
+
+		try{
+			var exec = require('child_process').exec;
+			//Run Cobol Check jar with arguments
+			var child = exec(executeJarCommand + ' ' + commandLineArgs, (error, stdout, stderr) => {
+				if(error !== null){
+					console.log("Error -> "+error);
+					vscode.window.showErrorMessage('Cobol Check ran with ' + error);
+				}
+				resolve(error ? stderr : stdout)
+			});
+
+		} catch (error){
+			console.error(error);
+			vscode.window.showErrorMessage('Could no launch Cobol Check: ' + error);
+			resolve(null);
+		}
+
+
+     });
+
+}
+
+export function getCobolProgramPathForGivenContext() : string{
+	let currentFile = vscode.window.activeTextEditor.document.uri.fsPath;
+	let workingDirectory = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.fsPath;
+
+	//Cobol file is open
+	if (currentFile.toLocaleUpperCase().endsWith('CBL') || currentFile.toLocaleUpperCase().endsWith('COB')){
+		lastProgramPath = currentFile;
+		return currentFile;
+	}
+	//.cut file is open
+	else if (currentFile.toLocaleUpperCase().endsWith('CUT')){
+		var path = require('path');
+		const cobolFileExtensions = ['.CBL', '.cbl', '.COB', '.cob'];
+		const programName = path.basename(path.dirname(currentFile))
+		for (let extension of cobolFileExtensions){
+			let programPath = findFile(programName + extension, workingDirectory);
+			if (programPath != null){
+				lastProgramPath = programPath;
+				return programPath;
+			}
+		}
+		vscode.window.showErrorMessage('Found no cobol program with the name: ' + programName);
+	}
+	//Other file is open
+	else{
+		if (lastProgramPath != null){
+			return lastProgramPath;
+		}
+		else{
+			vscode.window.showErrorMessage('No context available for which cobol program to run tests for');
+		}
+	}
+	return null;
+}
+
+export function getFileName(path : string, includeExtension : boolean) : string{
+	let programName : string = path.substring(path.lastIndexOf(getFileSeperatorForOS(currentPlatform))+1);
+	if (includeExtension) return programName;
+	return programName.substring(0, programName.indexOf('.'));
+}
+
+export function getSourceFolderContextPath(path : string, sourceFolderName : string) : string{
+	var lastFileSeperatorIndex : integer;
+	var lastFolder : string = null;
+	while (lastFolder !== sourceFolderName){
+		lastFileSeperatorIndex = path.lastIndexOf(getFileSeperatorForOS(currentPlatform));
+		if (lastFileSeperatorIndex !== -1){
+			lastFolder = path.substring(lastFileSeperatorIndex + 1);
+			//Get parent folder
+			path = path.substring(0, lastFileSeperatorIndex)
+		}
+		else{
+			vscode.window.showErrorMessage("Found no folder named '" + sourceFolderName + "' in path: " + path + ". If the source folder " +
+				"is named something else, configure cobol check for the following properties: [application.source.directory, " +
+				"application.copybook.directory, test.suite.directory]");
+			return null;
+		}
+	}
+	return path;
+}
+
+export function getRootFolder(path : string){
+	path = adjustPath(path);
+	let fileSeperatorIndex = path.indexOf(getFileSeperatorForOS(currentPlatform));
+	if (fileSeperatorIndex !== -1){
+		return path.substring(0, fileSeperatorIndex);
+	}
+	else{
+		return path;
+	}
+}
+
+function getOS() {
+	var platform = process.platform;
+	var	macosPlatformTag = 'darwin'
+	var	windowsPlatformTag = 'win32'
+	var	linuxPlatformTag = 'linux'
+  
+	if (platform === macosPlatformTag) {
+	  return macPlatform;
+	} else if (platform === windowsPlatformTag) {
+	  return windowsPlatform;
+	} else if (platform === linuxPlatformTag) {
+	  return linuxPlatform;
+	}
+	return platform;
+  }
+
+  function getFileSeperatorForOS(platform : string){
+	  if (platform === windowsPlatform) return '\\';
+	  else return '/';
+  }
+
+function adjustPath(path : string){
+	if (getFileSeperatorForOS(currentPlatform) === '/')
+		return path.split('\\').join('/');
+	else
+		return path.split('/').join('\\');
+}
+
+function findFile(name : String, path : string){
+
+	const fs = require('fs')
+
+	const files = fs.readdirSync(path)
+
+	for (let file of files) {
+		if (path.endsWith(getFileSeperatorForOS(currentPlatform))){
+			file = path + file;
+		}
+		else{
+			file = path + getFileSeperatorForOS(currentPlatform) + file;
+		}
+		if (fs.lstatSync(file).isDirectory()){
+			let returned = findFile(name, file);
+			if (returned != null){
+				return returned;
+			}
+		}
+		else{
+			let fileName : string = getFileName(adjustPath(file), true);
+			if (fileName === name){
+				return(file);
+			}
+		}
+	}
+	return null;
+}

--- a/vs code extension/client/src/services/ResultWebView.ts
+++ b/vs code extension/client/src/services/ResultWebView.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+
+export class ResultWebView implements vscode.WebviewViewProvider {
+
+	public static readonly viewType = 'cobolcheck-result';
+
+	private _view?: vscode.WebviewView;
+
+	constructor(
+		private readonly _extensionUri: vscode.Uri,
+	) { }
+
+	public resolveWebviewView(
+		webviewView: vscode.WebviewView,
+		context: vscode.WebviewViewResolveContext,
+		_token: vscode.CancellationToken,
+	) {
+		this._view = webviewView;
+
+		webviewView.webview.options = {
+			// Allow scripts in the webview
+			enableScripts: true,
+
+			localResourceRoots: [
+				this._extensionUri
+			]
+		};
+
+		webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+
+		webviewView.webview.onDidReceiveMessage( async data => {
+			switch (data.type) {
+				case 'command':
+					{
+						let success = await vscode.commands.executeCommand(data.value);
+						break;
+					}
+			}
+		});
+	}
+
+	public showTestResult(testResult : string) {
+		if (this._view) {
+			this._view.show?.(true); // `show` is not implemented in 1.49 but is for 1.50 insiders
+			let splittedString = testResult.split("=================================================");
+			if (splittedString.length > 0)
+				this._view.webview.postMessage({ type: 'test-result', value: splittedString[0] });
+		}
+	}
+
+	private _getHtmlForWebview(webview: vscode.Webview) {
+		// Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
+		const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.js'));
+
+		// Do the same for the stylesheet.
+		const styleResetUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'reset.css'));
+		const styleVSCodeUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'vscode.css'));
+		const styleMainUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.css'));
+
+		// Use a nonce to only allow a specific script to be run.
+		const nonce = this.getNonce();
+
+		return `<!DOCTYPE html>
+			<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<!--
+					Use a content security policy to only allow loading images from https or from our extension directory,
+					and only allow scripts that have a specific nonce.
+				-->
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<link href="${styleResetUri}" rel="stylesheet">
+				<link href="${styleVSCodeUri}" rel="stylesheet">
+				<link href="${styleMainUri}" rel="stylesheet">
+				
+				<title>Result</title>
+			</head>
+			<body>
+				<ul class="color-list">
+				</ul>
+				<button class="normal-button" id="cobolcheck-run-button">Run tests</button>
+				<p class = "line-break-text" id = "test-result-paragraph"> No test results to show yet </p>
+				<script nonce="${nonce}" src="${scriptUri}"></script>
+			</body>
+			</html>`;
+	}
+
+	private getNonce() {
+		let text = '';
+		const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		for (let i = 0; i < 32; i++) {
+			text += possible.charAt(Math.floor(Math.random() * possible.length));
+		}
+		return text;
+	}
+}

--- a/vs code extension/client/src/services/cutLanguageClientServerSetup.ts
+++ b/vs code extension/client/src/services/cutLanguageClientServerSetup.ts
@@ -1,0 +1,67 @@
+import * as path from 'path';
+import { workspace, ExtensionContext, window} from 'vscode';
+
+import {
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+	TransportKind,
+} from 'vscode-languageclient/node';
+
+import * as LOGGER from '../utils/Logger'
+
+let client: LanguageClient;
+
+export function startCutLanguageClientServer(context: ExtensionContext) {
+	// The server is implemented in node
+	let serverModule = context.asAbsolutePath(
+		path.join('server', 'out', 'server.js')
+	);
+	// The debug options for the server
+	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+	let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+
+	// If the extension is launched in debug mode then the debug server options are used
+	// Otherwise the run options are used
+	let serverOptions: ServerOptions = {
+		run: { module: serverModule, transport: TransportKind.ipc },
+		debug: {
+			module: serverModule,
+			transport: TransportKind.ipc,
+			options: debugOptions
+		}
+	};
+
+	// Options to control the language client
+	let clientOptions: LanguageClientOptions = {
+		// Register the server for cut documents
+		documentSelector: [{ scheme: 'file', language: 'cut' }],
+		synchronize: {
+			// Notify the server about file changes to '.clientrc files contained in the workspace
+			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
+		},
+		outputChannel: window.createOutputChannel('Cut Language Extension'),
+	};
+
+	// Create the language client and start the client.
+	client = new LanguageClient(
+		'cut',
+		'CUT',
+		serverOptions,
+		clientOptions
+	);
+
+	//Log information to a dedicated outputchannel
+	LOGGER.createLogger(clientOptions.outputChannel)
+	LOGGER.log('Starting Client', LOGGER.INFO)
+	
+	// Start the client. This will also launch the server
+	client.start();
+}
+
+export function stopCutLanguageClientServer(): Thenable<void> | undefined {
+	if (!client) {
+		return undefined;
+	}
+	return client.stop();
+}

--- a/vs code extension/client/tsconfig.json
+++ b/vs code extension/client/tsconfig.json
@@ -1,4 +1,5 @@
 {
+	"compileOnSave": true,
 	"compilerOptions": {
 		"module": "commonjs",
 		"target": "es2019",
@@ -7,6 +8,6 @@
 		"rootDir": "src",
 		"sourceMap": true
 	},
-	"include": ["src", "test"],
+	"include": ["src", "test", "Cobol-check"],
 	"exclude": ["node_modules", ".vscode-test"]
 }

--- a/vs code extension/images/run-dark.svg
+++ b/vs code extension/images/run-dark.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 2V14.4805L12.9146 8.24024L4 2ZM11.1809 8.24024L4.995 12.5684V3.91209L11.1809 8.24024Z" fill="#C5C5C5"/>
+</svg>

--- a/vs code extension/images/run-light.svg
+++ b/vs code extension/images/run-light.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.00024 2V14.4805L12.9149 8.24024L4.00024 2ZM11.1812 8.24024L4.99524 12.5684V3.91209L11.1812 8.24024Z" fill="#424242"/>
+</svg>

--- a/vs code extension/media/main.css
+++ b/vs code extension/media/main.css
@@ -1,0 +1,14 @@
+body {
+	background-color: transparent;
+}
+
+.normal-button {
+	display: block;
+	border: none;
+	margin: 50 auto;
+}
+
+.line-break-text {
+	white-space: pre;
+	margin: 10 auto;
+}

--- a/vs code extension/media/main.js
+++ b/vs code extension/media/main.js
@@ -1,0 +1,23 @@
+//@ts-check
+
+// This script will be run within the webview itself
+// It cannot access the main VS Code APIs directly.
+(function () {
+    const vscode = acquireVsCodeApi();
+
+    document.getElementById("cobolcheck-run-button").addEventListener('click', () => {
+        vscode.postMessage({ type: 'command', value: 'cobolcheck.run' });
+    });
+
+    // Handle messages sent from the extension to the webview
+    window.addEventListener('message', event => {
+        const message = event.data; // The json data that the extension sent
+        switch (message.type) {
+            case 'test-result':
+                {
+					document.getElementById('test-result-paragraph').textContent = message.value;
+                    break;
+                }
+        }
+    });
+}());

--- a/vs code extension/media/reset.css
+++ b/vs code extension/media/reset.css
@@ -1,0 +1,30 @@
+html {
+	box-sizing: border-box;
+	font-size: 13px;
+}
+
+*,
+*:before,
+*:after {
+	box-sizing: inherit;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
+	margin: 0;
+	padding: 0;
+	font-weight: normal;
+}
+
+img {
+	max-width: 100%;
+	height: auto;
+}

--- a/vs code extension/media/vscode.css
+++ b/vs code extension/media/vscode.css
@@ -1,0 +1,91 @@
+:root {
+	--container-paddding: 20px;
+	--input-padding-vertical: 6px;
+	--input-padding-horizontal: 4px;
+	--input-margin-vertical: 4px;
+	--input-margin-horizontal: 0;
+}
+
+body {
+	padding: 0 var(--container-paddding);
+	color: var(--vscode-foreground);
+	font-size: var(--vscode-font-size);
+	font-weight: var(--vscode-font-weight);
+	font-family: var(--vscode-font-family);
+	background-color: var(--vscode-editor-background);
+}
+
+ol,
+ul {
+	padding-left: var(--container-paddding);
+}
+
+body > *,
+form > * {
+	margin-block-start: var(--input-margin-vertical);
+	margin-block-end: var(--input-margin-vertical);
+}
+
+*:focus {
+	outline-color: var(--vscode-focusBorder) !important;
+}
+
+a {
+	color: var(--vscode-textLink-foreground);
+}
+
+a:hover,
+a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
+code {
+	font-size: var(--vscode-editor-font-size);
+	font-family: var(--vscode-editor-font-family);
+}
+
+button {
+	border: none;
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	width: 100%;
+	text-align: center;
+	outline: 1px solid transparent;
+	outline-offset: 2px !important;
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+}
+
+button:hover {
+	cursor: pointer;
+	background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+	outline-color: var(--vscode-focusBorder);
+}
+
+button.secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background: var(--vscode-button-secondaryBackground);
+}
+
+button.secondary:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+input:not([type='checkbox']),
+textarea {
+	display: block;
+	width: 100%;
+	border: none;
+	font-family: var(--vscode-font-family);
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	color: var(--vscode-input-foreground);
+	outline-color: var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+	color: var(--vscode-input-placeholderForeground);
+}

--- a/vs code extension/package.json
+++ b/vs code extension/package.json
@@ -14,10 +14,28 @@
         "vscode": "^1.46.0"
     },
     "activationEvents": [
-        "onLanguage:cut"
+        "onStartupFinished"
     ],
     "main": "./client/out/extension",
     "contributes": {
+        "viewsContainers": {
+            "activitybar": [
+                {
+                    "id": "cobol-check",
+                    "title": "Cobol Check",
+                    "icon": "images/cobol-check-logo-white-small.png"
+                }
+            ]
+        },
+        "views": {
+            "cobol-check": [
+                {
+                    "type": "webview",
+                    "id": "cobolcheck-result",
+                    "name": "Results"
+                }
+            ]
+        },
         "languages": [
             {
                 "id": "cut",
@@ -123,6 +141,22 @@
         },
         "commands": [
             {
+                "command": "cobolcheck.run",
+                "title": "Run Cobol Check",
+                "icon": {
+                    "light": "images/run-light.svg",
+                    "dark": "images/run-dark.svg"
+                }
+            },
+            {
+                "command": "cobolcheck.configure",
+                "title": "Configure Cobol Check"
+            },
+            {
+                "command": "cobolcheck.reset.configuration",
+                "title": "Reset Cobol Check Configurations"
+            },
+            {
                 "command": "zopeneditor.tab",
                 "title": "%zopeneditor.tab%",
                 "comment": "TODO: Remove Open Editor tab dependency. Also in keybindings"
@@ -161,5 +195,8 @@
         "eslint": "^6.4.0",
         "mocha": "^8.1.1",
         "typescript": "^4.2.2"
+    },
+    "dependencies": {
+        "@types/vscode-webview": "^1.57.0"
     }
 }

--- a/vs code extension/package.json
+++ b/vs code extension/package.json
@@ -8,7 +8,7 @@
         "Snippets"
     ],
     "description": "Extension for running unit tests in Cobol",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "icon": "images/cobol-check-logo-small.png",
     "engines": {
         "vscode": "^1.46.0"
@@ -142,7 +142,7 @@
         "commands": [
             {
                 "command": "cobolcheck.run",
-                "title": "Run Cobol Check",
+                "title": "CobolCheck: Run",
                 "icon": {
                     "light": "images/run-light.svg",
                     "dark": "images/run-dark.svg"
@@ -150,11 +150,11 @@
             },
             {
                 "command": "cobolcheck.configure",
-                "title": "Configure Cobol Check"
+                "title": "CobolCheck: Configure property"
             },
             {
                 "command": "cobolcheck.reset.configuration",
-                "title": "Reset Cobol Check Configurations"
+                "title": "CobolCheck: Reset configurations to default"
             },
             {
                 "command": "zopeneditor.tab",

--- a/vs code extension/server/package.json
+++ b/vs code extension/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cobol-check-extension-server",
 	"description": "Implementation of a cobol unit test language server in node.",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"author": "Bankdata",
 	"license": "MIT",
 	"engines": {


### PR DESCRIPTION
### Vs Code Extension
- Integrated Cobol Check into extension
- Added new release information
- Added commands for
      - Running Cobol Check
      - Setting a configuration value
      - Resetting config file to default

### Cobol Check
- Added command argument: source context. In what path context can the src/main/cobol folder be found.
- Fixed minor bugs