### PR TITLE
Extension fix

### DIFF
--- a/src/main/java/org/openmainframeproject/cobolcheck/Main.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/Main.java
@@ -3,11 +3,7 @@ package org.openmainframeproject.cobolcheck;
 import org.openmainframeproject.cobolcheck.workers.CobolTestRunner;
 import org.openmainframeproject.cobolcheck.workers.Generator;
 import org.openmainframeproject.cobolcheck.workers.Initializer;
-//The main class
 class Main {
-
-
-
 
     public static void main(String[] args) throws InterruptedException {
         Initializer initializer = new Initializer(args);

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandlerController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/argumentHandler/ArgumentHandlerController.java
@@ -32,6 +32,9 @@ public class ArgumentHandlerController {
         if (isKeySet("source-context")){
             Config.setSourceFolderContext(getKeyValue("source-context"));
         }
+        if (isKeySet("run-directory")){
+            Config.setRunDirectory(getKeyValue("run-directory"));
+        }
 
         //Load paths in program values
         argumentHandler.loadArgProgramPaths();

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/LinuxProcessLauncher.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/LinuxProcessLauncher.java
@@ -48,11 +48,10 @@ public class LinuxProcessLauncher implements ProcessLauncher {
             Log.error(Messages.get("ERR021", processConfigKey));
             throw new PossibleInternalLogicErrorException(Messages.get("ERR021", processConfigKey));
         }
-        String scriptDirectory = Config.getString(Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY,
-                Constants.DEFAULT_COBOLCHECK_SCRIPT_DIRECTORY);
+        String scriptDirectory = Config.getScriptDirectory();
         if (StringHelper.isBlank(scriptDirectory)) {
-            Log.error(Messages.get("ERR022", Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
-            throw new PossibleInternalLogicErrorException(Messages.get("ERR022", Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
+            Log.error(Messages.get("ERR022", Config.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
+            throw new PossibleInternalLogicErrorException(Messages.get("ERR022", Config.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
         }
 
         if (!scriptDirectory.endsWith(Constants.FILE_SEPARATOR)) {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/WindowsProcessLauncher.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/WindowsProcessLauncher.java
@@ -42,11 +42,10 @@ public class WindowsProcessLauncher implements ProcessLauncher {
             Log.error(Messages.get("ERR021", processConfigKey));
             throw new PossibleInternalLogicErrorException(Messages.get("ERR021", processConfigKey));
         }
-        String scriptDirectory = Config.getString(Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY,
-                Constants.DEFAULT_COBOLCHECK_SCRIPT_DIRECTORY);
+        String scriptDirectory = Config.getScriptDirectory();
         if (StringHelper.isBlank(scriptDirectory)) {
-            Log.error(Messages.get("ERR022", Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
-            throw new PossibleInternalLogicErrorException(Messages.get("ERR022", Constants.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
+            Log.error(Messages.get("ERR022", Config.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
+            throw new PossibleInternalLogicErrorException(Messages.get("ERR022", Config.COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY));
         }
 
         if (!scriptDirectory.endsWith(Constants.FILE_SEPARATOR)) {

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
@@ -58,6 +58,8 @@ public class Config {
     public static final String DEFAULT_COPY_SOURCE_DIRECTORY = "src/main/cobol/copy";
     public static final String TESTSUITE_DIRECTORY_CONFIG_KEY = "test.suite.directory";
     public static final String DEFAULT_TESTSUITE_DIRECTORY = "src/test/cobol";
+    public static final String COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY = "cobolcheck.script.directory";
+    public static final String DEFAULT_COBOLCHECK_SCRIPT_DIRECTORY = "./";
 
     private static Properties settings = null;
 
@@ -104,6 +106,11 @@ public class Config {
 
     public static Locale getDefaultLocale() { return (Locale) settings.get(DEFAULT_LOCALE_CONFIG_KEY); }
 
+    static String runDirectory = null;
+    public static void setRunDirectory(String value) {
+        runDirectory = value;
+    }
+
     private static String testCodePrefix = "";
     public static String getTestCodePrefix() {
         if (testCodePrefix.isEmpty()){
@@ -143,13 +150,11 @@ public class Config {
     }
 
     public static String getGeneratedTestCodePath() {
-        return StringHelper.adjustPathString(settings.getProperty(GENERATED_CODE_PATH,
-                Constants.CURRENT_DIRECTORY));
+        return getCorrectRunContext(settings.getProperty(GENERATED_CODE_PATH, Constants.CURRENT_DIRECTORY));
     }
 
     public static String getTestsuiteparserErrorLogPath() {
-        return StringHelper.adjustPathString(settings.getProperty(TESTSUITEPARSER_ERROR_LOG_PATH,
-                Constants.CURRENT_DIRECTORY));
+        return getCorrectRunContext(settings.getProperty(TESTSUITEPARSER_ERROR_LOG_PATH, Constants.CURRENT_DIRECTORY));
     }
 
     private static String testSuiteParserErrorLogFileName = "";
@@ -192,7 +197,7 @@ public class Config {
 
     public static String getTestResultFilePathString() {
         String pathFromConfig = settings.getProperty(TEST_RESULTS_FILE_CONFIG_KEY, Constants.CURRENT_DIRECTORY);
-        return StringHelper.adjustPathString(StringHelper.changeFileExtension(pathFromConfig, getTestResultFormat().name()));
+        return getCorrectRunContext(StringHelper.changeFileExtension(pathFromConfig, getTestResultFormat().name()));
     }
 
     static String generatedTestFileName = "";
@@ -210,10 +215,10 @@ public class Config {
     static String concatenatedTestSuitePath = "";
     public static String getConcatenatedTestSuitesPath(){
         if (concatenatedTestSuitePath.isEmpty()){
-            concatenatedTestSuitePath = StringHelper.adjustPathString(settings.getProperty(
-                    Constants.CONCATENATED_TEST_SUITES_CONFIG_KEY, Constants.CURRENT_DIRECTORY));
+            concatenatedTestSuitePath = settings.getProperty(Constants.CONCATENATED_TEST_SUITES_CONFIG_KEY,
+                    Constants.CURRENT_DIRECTORY);
         }
-        return concatenatedTestSuitePath;
+        return getCorrectRunContext(concatenatedTestSuitePath);
     }
 
     public static void setConcatenatedTestSuitesPath(String keyValue)
@@ -265,8 +270,7 @@ public class Config {
     }
 
     public static boolean getRunGeneratedTest() {
-        String value = StringHelper.adjustPathString(settings.getProperty(RUN_GENERATED_TESTS,
-                Constants.CURRENT_DIRECTORY));
+        String value = settings.getProperty(RUN_GENERATED_TESTS, Constants.CURRENT_DIRECTORY);
         return Boolean.parseBoolean(value.trim());
     }
     private static String sourceFolderContext = null;
@@ -316,6 +320,11 @@ public class Config {
         return (List<String>) settings.get(RESOLVED_APPLICATION_COPYBOOK_FILENAME_SUFFIX);
     }
 
+    public static String getScriptDirectory() {
+        return getCorrectRunContext(settings.getProperty(COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY,
+                DEFAULT_COBOLCHECK_SCRIPT_DIRECTORY));
+    }
+
     private static void setCopybookFilenameSuffix() {
         resolveFilenameSuffixes(APPLICATION_COPYBOOK_FILENAME_SUFFIX, RESOLVED_APPLICATION_COPYBOOK_FILENAME_SUFFIX);
     }
@@ -350,5 +359,15 @@ public class Config {
                     settings.getProperty(LOCALE_VARIANT_CONFIG_KEY));
         }
         settings.put(DEFAULT_LOCALE_CONFIG_KEY, locale);
+    }
+
+    private static String getCorrectRunContext(String path){
+        if (runDirectory != null){
+            if (path.startsWith(".") && path.length() > 0){
+                path = path.substring(1);
+            }
+            return StringHelper.adjustPathString(PathHelper.endWithFileSeparator(runDirectory) + path);
+        }
+        return StringHelper.adjustPathString(path);
     }
 }

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -24,8 +24,8 @@ public final class Constants {
     public static final String COBOLCHECK_COPYBOOK_DIRECTORY = COBOLCHECK_PACKAGE_PATH + "/copybooks/";
 
     //Command line options
-    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:g:a:e:s:vh " +
-            "--long config-file:,log-level:,programs:,tests:,generated-tests:,all-tests:,error-log:,source-context:,version,help";
+    public static final String COMMAND_lINE_OPTIONS = "c:l:p:t:g:a:e:s:r:vh " +
+            "--long config-file:,log-level:,programs:,tests:,generated-tests:,all-tests:,error-log:,source-context:,run-directory:,version,help";
 
     // Frequently-used string values
     public static final String EMPTY_STRING = "";
@@ -93,8 +93,6 @@ public final class Constants {
     public static final String DEFAULT_CONCATENATED_TEST_SUITES_PATH = "./ALLTESTS";
     public static final String TEST_PROGRAM_NAME_CONFIG_KEY = "cobolcheck.test.program.name";
     public static final String DEFAULT_TEST_PROGRAM_NAME = "CC$$99.CBL";
-    public static final String COBOLCHECK_SCRIPT_DIRECTORY_CONFIG_KEY = "cobolcheck.script.directory";
-    public static final String DEFAULT_COBOLCHECK_SCRIPT_DIRECTORY = "./";
     public static final String PROCESS_CONFIG_KEY = ".process";
     public static final String COBOLCHECK_PREFIX_CONFIG_KEY = "cobolcheck.prefix";
     public static final String DEFAULT_COBOLCHECK_PREFIX = "UT-";

--- a/vs code extension/CHANGELOG.md
+++ b/vs code extension/CHANGELOG.md
@@ -23,3 +23,8 @@ All notable changes to the "cobol-unit-test" extension will be documented in thi
 ## [0.2.1] 19.05.2022
 
 - Added error handling and messages
+
+## [0.2.2] 20.05.2022
+
+- Fixed bug where the path to Cobol Check would be incorrect
+

--- a/vs code extension/client/package.json
+++ b/vs code extension/client/package.json
@@ -3,7 +3,7 @@
 	"description": "Cobol-check extension to run cobol unit tests",
 	"author": "Open Mainframe Project",
 	"license": "MIT",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"publisher": "openmainframeproject",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vs code extension/client/src/extension.ts
+++ b/vs code extension/client/src/extension.ts
@@ -9,13 +9,15 @@
 import * as vscode from 'vscode';
 import { workspace, ExtensionContext, window} from 'vscode';
 import { getConfigurationMap, getConfigurationValueFor, resetConfigurations, setConfiguration } from './services/CobolCheckConfiguration';
-import { getCobolProgramPathForGivenContext, getFileName, getRootFolder, getSourceFolderContextPath, runCobolCheck } from './services/CobolCheckLauncher';
+import { appendPath, getCobolProgramPathForGivenContext, getFileName, getRootFolder, getSourceFolderContextPath, runCobolCheck } from './services/CobolCheckLauncher';
 
 import { startCutLanguageClientServer, stopCutLanguageClientServer } from './services/cutLanguageClientServerSetup';
 import { ResultWebView } from './services/ResultWebView';
 
-let configPath = 'Cobol-check/config.properties';
-let defaultConfigPath = 'Cobol-check/default.properties';
+let externalVsCodeInstallationDir = vscode.extensions.getExtension("openmainframeproject.cobol-check-extension").extensionPath;
+let configPath = appendPath(externalVsCodeInstallationDir, 'Cobol-check/config.properties');
+let defaultConfigPath = appendPath(externalVsCodeInstallationDir, 'Cobol-check/default.properties');
+let cobolCheckJarPath = appendPath(externalVsCodeInstallationDir, 'Cobol-check/bin/cobol-check-0.1.0.jar');
 
 let lastCurrentFile = null;
 let cutLanguageRunning = false;
@@ -42,9 +44,10 @@ export function activate(context: ExtensionContext) {
 			let applicationSourceDir = await getConfigurationValueFor(configPath, 'application.source.directory');
 			let srcFolderContext : string = getSourceFolderContextPath(programPath, getRootFolder(applicationSourceDir));
 			if (srcFolderContext === null) return;
-			let argument : string = '-p ' + programName + ' -c ' + configPath + ' -s "' + srcFolderContext + '"'
+			let argument : string = '-p ' + programName + ' -c "' + configPath + '" -s "' + srcFolderContext + '" ' +
+				'-r "' + externalVsCodeInstallationDir + '"';
 			//Running Cobol Check
-			let output = await runCobolCheck(argument)
+			let output = await runCobolCheck(cobolCheckJarPath, argument)
 			if (output !== null)
 				provider.showTestResult(output);
 			else

--- a/vs code extension/client/src/services/CobolCheckLauncher.ts
+++ b/vs code extension/client/src/services/CobolCheckLauncher.ts
@@ -4,6 +4,7 @@ import { integer } from 'vscode-languageclient';
 let cobolCheckJar_Windows = '@java -jar Cobol-check\\bin\\cobol-check-0.1.0.jar';
 let cobolCheckJar_Linux_Mac = 'java -jar Cobol-check/bin/cobol-check-0.1.0.jar $@';
 
+
 const windowsPlatform = 'Windows';
 const macPlatform = 'MacOS';
 const linuxPlatform = 'Linux';
@@ -12,14 +13,14 @@ let currentPlatform = getOS();
 
 let lastProgramPath : string = null;
 
-export async function runCobolCheck(commandLineArgs : string) : Promise<string> {
+export async function runCobolCheck(path : string, commandLineArgs : string) : Promise<string> {
 	return new Promise(async resolve => {
 		// Getting the right command based on platform
 		let executeJarCommand = '';
 		if (currentPlatform === windowsPlatform){
-			executeJarCommand = cobolCheckJar_Windows;
+			executeJarCommand = '@java -jar "' + path + '"';
 		}else if (currentPlatform === macPlatform || currentPlatform === linuxPlatform){
-			executeJarCommand = cobolCheckJar_Linux_Mac;
+			executeJarCommand = 'java -jar "' + path + '" $@';
 		} else{
 			vscode.window.showErrorMessage('Only Windows, Mac OS and Linux are supported for running Cobol Check. ' + 
 				'Your platform: ' + currentPlatform + ' is not supported');
@@ -130,6 +131,10 @@ export function getRootFolder(path : string){
 	else{
 		return path;
 	}
+}
+
+export function appendPath(path1 : string, path2 : string){
+	return adjustPath(path1) + getFileSeperatorForOS(currentPlatform) + adjustPath(path2);
 }
 
 function getOS() {

--- a/vs code extension/package.json
+++ b/vs code extension/package.json
@@ -8,7 +8,7 @@
         "Snippets"
     ],
     "description": "Extension for running unit tests in Cobol",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "icon": "images/cobol-check-logo-small.png",
     "engines": {
         "vscode": "^1.46.0"

--- a/vs code extension/server/package.json
+++ b/vs code extension/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cobol-check-extension-server",
 	"description": "Implementation of a cobol unit test language server in node.",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"author": "Bankdata",
 	"license": "MIT",
 	"engines": {


### PR DESCRIPTION
- Added command argument for run-directory. Where Cobol Check is being run from and where its running might be two different directories, which makes relative paths unusable. This fixes that problem.

- Fixed bug in extension where the path to Cobol Check was incorrect.