### PR TITLE
Bug Fix regarding EXIT-statements

### DIFF
--- a/src/main/cobol/MOCKTEST.CBL
+++ b/src/main/cobol/MOCKTEST.CBL
@@ -53,15 +53,21 @@
               EXIT PARAGRAPH
            END-EVALUATE.
 
-       400-CHANGE-2
+       400-CHANGE-2 SECTION
           .
            EVALUATE VALUE-2
            WHEN "Hi"
               MOVE "See you" TO VALUE-2
+              EXIT SECTION
            WHEN OTHER
               MOVE "Hi" TO VALUE-2
+              EXIT SECTION
            END-EVALUATE
           .
+
+       410-PLACEHOLDER SECTION.
+           CONTINUE
+           .
 
        500-SWITCH.
            MOVE VALUE-2 TO TEMP

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
@@ -115,8 +115,6 @@ public class InterpreterController {
         if (Interpreter.containsOnlyPeriod(reader.getCurrentLine()))
             return true;
         else {
-            if (Interpreter.containsParagraphOrSectionEndingToken(reader.getCurrentLine()))
-                return true;
             if (Interpreter.endsInPeriod(reader.getCurrentLine())){
                     reader.putNextLine("           .");
                     return false;

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
@@ -20,10 +20,6 @@ public class Interpreter {
             "OPEN", "CLOSE", "READ", "WRITE", "REWRITE", "DELETE", "START"
     );
 
-    private static final List<String> paragraphAndSectionEndingTokens = Arrays.asList(
-            Constants.EXIT_TOKEN, Constants.END_SECTION_TOKEN, Constants.END_PARAGRAPH_TOKEN
-    );
-
     // Used for handling source lines from copybooks that may not have the standard 80-byte length
     private static final int minimumMeaningfulSourceLineLength = 7;
     private static final int commentIndicatorOffset = 6;
@@ -174,19 +170,8 @@ public class Interpreter {
         if (currentLine == null || nextLine == null || lineFollowingNext == null)
             return true;
 
-        if (containsParagraphOrSectionEndingToken(currentLine))
-            return true;
-
         if (endsInPeriod(currentLine) || containsOnlyPeriod(currentLine)){
             return (isSectionHeader(nextLine, state) || isParagraphHeader(nextLine, lineFollowingNext, state));
-        }
-        return false;
-    }
-
-    public static boolean containsParagraphOrSectionEndingToken(CobolLine currentLine){
-        for (String keyword : paragraphAndSectionEndingTokens){
-            if (currentLine.containsToken(keyword))
-                return true;
         }
         return false;
     }

--- a/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
+++ b/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
@@ -81,3 +81,10 @@
            PERFORM 300-CHANGE-1
            Expect VALUE-1 to be "MOCKED"
            Expect VALUE-2 to be "Hi"
+
+           TestCase "Mock with EXIT SECTION in source works"
+           MOCK SECTION 400-CHANGE-2
+                MOVE "Exit section is handled correctly" TO VALUE-1
+           END-MOCK
+           PERFORM 400-CHANGE-2
+           Expect VALUE-1 to be "Exit section is handled correctly"

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
@@ -297,8 +297,8 @@ public class MockIT {
                     "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
                     "           WHEN OTHER                                                           " + Constants.NEWLINE +
                     "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
-                    "            END-EVALUATE                                                        " + Constants.NEWLINE +
                     "           EXIT SECTION                                                         " + Constants.NEWLINE +
+                    "            END-EVALUATE                                                        " + Constants.NEWLINE +
                     "           .                                                                   "  + Constants.NEWLINE;
 
     private String expected2 =
@@ -443,8 +443,9 @@ public class MockIT {
             "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
+            "           EXIT SECTION                                                         " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
-            "           EXIT SECTION.                                                        " + Constants.NEWLINE +
+            "           .                                                                    " + Constants.NEWLINE +
             "       100-WELCOME SECTION.                                                     " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
@@ -670,8 +671,9 @@ public class MockIT {
             "                    PERFORM UT-1-2-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "           MOVE \"Value1\" to VALUE-1                                             " + Constants.NEWLINE +
+            "           EXIT SECTION                                                        " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
-            "           EXIT SECTION.                                                        " + Constants.NEWLINE +
+            "           .                                                                    " + Constants.NEWLINE +
             "       100-WELCOME SECTION.                                                     " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +


### PR DESCRIPTION
Fixed bug where EXIT SECTION, EXIT PARAGRAPH or EXIT would end the EVALUATE-statement of a MOCK.