### PR TITLE
Stable bug fix

### DIFF
--- a/src/main/cobol/MOCKTEST.CBL
+++ b/src/main/cobol/MOCKTEST.CBL
@@ -24,7 +24,7 @@
            PERFORM 300-CHANGE-1
            PERFORM 400-CHANGE-2
            PERFORM 500-SWITCH
-           PERFORM 999-END
+           PERFORM 998-END
            EXIT SECTION.
 
        100-WELCOME SECTION
@@ -100,6 +100,31 @@
               VALUE-3
           CALL 'PROG3' USING VALUE-1.
 
-       999-END.
+       850-ONLY-CALL SECTION.
+           CALL 'PROG222' USING VALUE-1
+           .
+
+       851-PLACEHOLDER SECTION.
+           EXEC SQL
+               OPEN CRS-AFVPRIS
+
+               MOVE SOMETHING SQL STATEMENT YEAH!
+               EXIT SECTION
+               .
+               .
+      *comment
+           END-EXEC
+           .
+
+       998-END.
            GOBACK
            .
+
+       999-TEST SECTION.
+           CALL 'PROG111' USING VALUE-1
+           .
+      *    Fejlmelde sektionerne findes i:
+      *    COPY BDSDA2FK.
+      *
+      *<<< SLUT INCLUDE BDSDA29K
+      *

--- a/src/main/cobol/MOCKTEST.CBL
+++ b/src/main/cobol/MOCKTEST.CBL
@@ -1,7 +1,7 @@
        IDENTIFICATION DIVISION.
-       PROGRAM-ID.  ALPHA.
+       PROGRAM-ID.  MOCKTEST.
       *****************************************************************
-      * Program to exercise EXPECT statements.
+      * Program to exercise different mock statements and edge cases.
       *****************************************************************
        ENVIRONMENT DIVISION.
        INPUT-OUTPUT SECTION.
@@ -24,7 +24,7 @@
            PERFORM 300-CHANGE-1
            PERFORM 400-CHANGE-2
            PERFORM 500-SWITCH
-           PERFORM 998-END
+           PERFORM 999-END
            EXIT SECTION.
 
        100-WELCOME SECTION
@@ -90,41 +90,16 @@
            MOVE "arg1" to VALUE-1
            MOVE "arg2" to VALUE-2
            MOVE "arg3" to VALUE-3
-           CALL 'PROG3' USING 
+           CALL 'PROG3' USING
               BY CONTENT VALUE-1,
-              BY VALUE VALUE-2,  
+              BY VALUE VALUE-2,
               VALUE-3.
-           CALL 'PROG3' USING 
+           CALL 'PROG3' USING
               BY CONTENT VALUE-1,
-              BY VALUE VALUE-2,  
+              BY VALUE VALUE-2,
               VALUE-3
           CALL 'PROG3' USING VALUE-1.
 
-       850-ONLY-CALL SECTION.
-           CALL 'PROG222' USING VALUE-1
-           .
-
-       851-PLACEHOLDER SECTION.
-           EXEC SQL
-               OPEN CRS-AFVPRIS
-
-               MOVE SOMETHING SQL STATEMENT YEAH!
-               EXIT SECTION
-               .
-               .
-      *comment
-           END-EXEC
-           .
-
-       998-END.
+       999-END.
            GOBACK
            .
-
-       999-TEST SECTION.
-           CALL 'PROG111' USING VALUE-1
-           .
-      *    Fejlmelde sektionerne findes i:
-      *    COPY BDSDA2FK.
-      *
-      *<<< SLUT INCLUDE BDSDA29K
-      *

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CobolReader.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/CobolReader.java
@@ -132,6 +132,21 @@ public class CobolReader {
     }
 
     /**
+     * Removes the last period from the current line
+     *
+     * @return The line, with the last period removed
+     */
+    CobolLine removePeriodFromCurrentLine(){
+        int indexOfLastPeriod = currentLine.getOriginalString().lastIndexOf('.');
+        if (indexOfLastPeriod < 0)
+            return currentLine;
+
+        currentLine = new CobolLine(currentLine.getOriginalString().substring(0, indexOfLastPeriod), tokenExtractor);
+        return currentLine;
+    }
+
+
+    /**
      * Turns the current read line into a read statement (if not already a statement).
      * Adds the given line as the first statement line.
      * @param line - The line to add
@@ -171,7 +186,11 @@ public class CobolReader {
      */
     CobolLine peekNextMeaningfulLine() throws IOException {
         if (!nextLines.isEmpty()){
-            return nextLines.get(nextLines.size() - 1);
+            for (int i = 1; i <= nextLines.size(); i++){
+                CobolLine currentLine = nextLines.get(nextLines.size() - i);
+                if (Interpreter.isMeaningful(currentLine))
+                    return currentLine;
+            }
         }
         while (true){
             String line = reader.readLine();

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/StringTokenizerExtractor.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/StringTokenizerExtractor.java
@@ -38,6 +38,7 @@ public class StringTokenizerExtractor implements TokenExtractor {
         expectedTokens.put("WORKING-STORAGE", Arrays.asList("SECTION"));
         expectedTokens.put("LOCAL-STORAGE", Arrays.asList("SECTION"));
         expectedTokens.put("BY", Arrays.asList("REFERENCE", "CONTENT", "VALUE"));
+        expectedTokens.put("EXEC", Arrays.asList("SQL", "CICS"));
     }
 
     /**

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -139,7 +139,12 @@ public class Keywords {
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
-                                Constants.COBOL_TOKEN),
+                                Constants.COBOL_TOKEN,
+                                Constants.TESTSUITE_KEYWORD,
+                                Constants.TESTCASE_KEYWORD,
+                                Constants.MOCK_KEYWORD,
+                                Constants.VERIFY_KEYWORD,
+                                Constants.EXPECT_KEYWORD),
                         KeywordAction.COBOL_STATEMENT));
         keywordInfo.put(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                 new Keyword(Constants.ALPHANUMERIC_LITERAL_KEYWORD,

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockGenerator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockGenerator.java
@@ -13,6 +13,7 @@ public class MockGenerator {
     private final String testCaseIdentifier = "%sTEST-CASE-NAME";
     private final String performFormat = "                    PERFORM %s";
     private final String endEvaluateLine = "            END-EVALUATE";
+    private final String continueLine = "            CONTINUE";
 
     private final String countMockInitialWSHeader = "       01  %sMOCKS-GENERATED.";
     private final String initializeMockCountParagraphHeader = "       %sINITIALIZE-MOCK-COUNT.";
@@ -126,11 +127,15 @@ public class MockGenerator {
         return endEvaluateLine;
     }
 
+    String getContinueLine() {
+        return continueLine;
+    }
+
     private List<String> generateMockCountValues(List<Mock> mocks) {
         List<String> lines = new ArrayList<>();
         for (Mock mock : mocks){
-            lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(02) VALUE ZERO COMP.");
-            lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(02) VALUE ZERO COMP.");
+            lines.add("           05  " + mock.getGeneratedMockCountIdentifier() + "       PIC 9(18) VALUE ZERO COMP.");
+            lines.add("           05  " + mock.getGeneratedMockCountExpectedIdentifier() + "    PIC 9(18) VALUE ZERO COMP.");
             lines.add("           05  " + mock.getGeneratedMockStringIdentifierName() + "        PIC X(40)");
             lines.add("                   VALUE \"" + mock.getMockDisplayString() + "\".");
         }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParserController.java
@@ -34,7 +34,7 @@ public class TestSuiteParserController {
     private static final String procedureDivisionResultCopybookFilename = "CCHECKRESULTPD.CPY";
     private static final String procedureDivisionParagraphCopybookFilename = "CCHECKPARAGRAPHSPD.CPY";
 
-    private static final String[] copyBookTokensWithPeriodAsDecimalPoint = new String[]{"Z,ZZ9"};
+    private static final String[] copyBookTokensWithPeriodAsDecimalPoint = new String[]{"ZZZ,ZZZ,ZZZ,ZZZ,ZZZ,ZZ9"};
 
     private final String workingStorageHeader = ("       WORKING-STORAGE SECTION.");
 
@@ -254,6 +254,13 @@ public class TestSuiteParserController {
     public List<String> getEndEvaluateLine(){
         List<String> lines = new ArrayList<>();
         lines.add(mockGenerator.getEndEvaluateLine());
+        CobolGenerator.addStartAndEndTags(lines);
+        return lines;
+    }
+
+    public List<String> getContinueLine(){
+        List<String> lines = new ArrayList<>();
+        lines.add(mockGenerator.getContinueLine());
         CobolGenerator.addStartAndEndTags(lines);
         return lines;
     }

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Config.java
@@ -42,7 +42,8 @@ public class Config {
     public static final String LOCALE_COUNTRY_CONFIG_KEY = "locale.country";
     public static final String LOCALE_VARIANT_CONFIG_KEY = "locale.variant";
     public static final String DEFAULT_LOCALE_CONFIG_KEY = "default.locale";
-    public static final String RUN_GENERATED_TESTS = "cobolcheck.test.run";
+    public static final String RUN_GENERATED_TESTS_CONFIG_KEY = "cobolcheck.test.run";
+    public static final String RUN_GENERATED_TESTS_DEAFAULT = "true";
     public static final String RESOLVED_APPLICATION_SOURCE_FILENAME_SUFFIX = "resolved.application.source.filename.suffix";
     public static final String APPLICATION_SOURCE_FILENAME_SUFFIX = "application.source.filename.suffix";
     public static final String RESOLVED_APPLICATION_COPYBOOK_FILENAME_SUFFIX = "resolved.application.copybook.filename.suffix";
@@ -275,7 +276,7 @@ public class Config {
     }
 
     public static boolean getRunGeneratedTest() {
-        String value = settings.getProperty(RUN_GENERATED_TESTS, Constants.CURRENT_DIRECTORY);
+        String value = settings.getProperty(RUN_GENERATED_TESTS_CONFIG_KEY, RUN_GENERATED_TESTS_DEAFAULT);
         return Boolean.parseBoolean(value.trim());
     }
     private static String sourceFolderContext = null;

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -137,6 +137,10 @@ public final class Constants {
     public static final String ZERO_TOKEN = "ZERO";
     public static final String REPLACE_TOKEN = "REPLACE";
     public static final String CBL_TOKEN = "CBL";
+    public static final String EXEC_SQL_TOKEN = "EXEC SQL";
+    public static final String EXEC_CICS_TOKEN = "EXEC CICS";
+    public static final String END_EXEC_TOKEN = "END-EXEC";
+    public static final String CONTINUE_TOKEN = "CONTINUE";
 
     public static final String COMP_3_VALUE = "COMP-3";
     public static final String COMP_VALUE = "COMP";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
@@ -178,6 +178,9 @@ public class StringHelper {
     }
 
     public static int getNumberOfLeadingSpaces(String line){
+        if (line.length() == 0)
+            return 0;
+
         char[] characters = line.toCharArray();
         int index = 0;
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/CobolLine.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/CobolLine.java
@@ -91,4 +91,16 @@ public class CobolLine {
         }
         return -1;
     }
+
+    /**
+     * Checks if this line ends with the specified string - not case-sensitive. The string
+     * has to be a single token.
+     *
+     * @param tokenValue - The string token, to look for.
+     *
+     * @return (boolean) true if this line ends with the token
+     */
+    public boolean endsWithToken(String tokenValue) {
+        return tokens.size() > 0 && tokens.get(tokensSize() - 1) == tokenValue.toUpperCase(Locale.ROOT);
+    }
 }

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/cobolLogic/Interpreter.java
@@ -242,12 +242,28 @@ public class Interpreter {
      */
     public static boolean shouldLineBeStubbed(CobolLine line, State state){
         if (state.isFlagSetFor(Constants.PROCEDURE_DIVISION)){
-            if (checkForBatchFileIOStatement(line) || line.containsToken(Constants.CALL_TOKEN))
+            if (checkForBatchFileIOStatement(line) || line.containsToken(Constants.CALL_TOKEN) ||
+                    line.containsToken(Constants.EXEC_SQL_TOKEN) || line.containsToken(Constants.EXEC_CICS_TOKEN))
             {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * @param line
+     * @param state
+     * @return true if the source line should be commented out
+     */
+    public static String getStubEndToken(CobolLine line, State state){
+        if (state.isFlagSetFor(Constants.PROCEDURE_DIVISION)){
+            if (line.containsToken(Constants.EXEC_SQL_TOKEN) || line.containsToken(Constants.EXEC_CICS_TOKEN))
+            {
+                return Constants.END_EXEC_TOKEN;
+            }
+        }
+        return null;
     }
 
     /**
@@ -415,5 +431,17 @@ public class Interpreter {
      */
     public static boolean endsInPeriod(CobolLine line) {
         return line.getTrimmedString().endsWith(Constants.PERIOD);
+    }
+
+    /**
+     * Checks if the last of these lines is ending the current component (SECTION, CALL, etc.)
+     * This should be called from inside the component, as it only checks, if
+     * the trimmed line ends with a period
+     *
+     * @param lines - the lines to check
+     * @return true if the last line (trimmed) ends with a period
+     */
+    public static boolean endsInPeriod(List<CobolLine> lines) {
+        return lines.size() > 0 && lines.get(lines.size() - 1).getTrimmedString().endsWith(Constants.PERIOD);
     }
 }

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
@@ -96,7 +96,6 @@ public class Generator {
 
                 processingAfterEchoingSourceLineToOutput();
             }
-            handleEndOfFile();
             testSuiteParserController.logUnusedMocks();
             testSuiteParserController.prepareNextParse();
         } catch (IOException ioEx) {
@@ -202,14 +201,6 @@ public class Generator {
                 if (type.equals(Constants.SECTION_TOKEN) || type.equals(Constants.PARAGRAPH_TOKEN))
                     interpreter.setInsideSectionOrParagraphMockBody(true);
             }
-        }
-    }
-
-    private void handleEndOfFile() throws IOException {
-        if (interpreter.isInsideSectionOrParagraphMockBody()) {
-            interpreter.setInsideSectionOrParagraphMockBody(false);
-            writerController.writeLines(testSuiteParserController.getEndEvaluateLine());
-            writerController.writeLine("           .");
         }
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
@@ -96,6 +96,7 @@ public class Generator {
 
                 processingAfterEchoingSourceLineToOutput();
             }
+            handleEndOfFile();
             testSuiteParserController.logUnusedMocks();
             testSuiteParserController.prepareNextParse();
         } catch (IOException ioEx) {
@@ -201,6 +202,14 @@ public class Generator {
                 if (type.equals(Constants.SECTION_TOKEN) || type.equals(Constants.PARAGRAPH_TOKEN))
                     interpreter.setInsideSectionOrParagraphMockBody(true);
             }
+        }
+    }
+
+    private void handleEndOfFile() throws IOException {
+        if (interpreter.isInsideSectionOrParagraphMockBody()) {
+            interpreter.setInsideSectionOrParagraphMockBody(false);
+            writerController.writeLines(testSuiteParserController.getEndEvaluateLine());
+            writerController.writeLine("           .");
         }
     }
 

--- a/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKPARAGRAPHSPD.CPY
+++ b/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKPARAGRAPHSPD.CPY
@@ -175,14 +175,27 @@
                     END-IF
            END-EVALUATE
 
+           MOVE FUNCTION TRIM(==UT==EXPECTED-ACCESSES-FMT) 
+              TO ==UT==EXPECTED-ACCESSES-DISP
+           MOVE FUNCTION TRIM(==UT==ACTUAL-ACCESSES-FMT) 
+              TO ==UT==ACTUAL-ACCESSES-DISP
+              
+
+
            IF ==UT==VERIFY-PASSED
                ADD 1 TO ==UT==NUMBER-PASSED
-               DISPLAY ==UT==PASSED
-                       ==UT==TEST-CASE-NUMBER '. '
-                      'VERIFY ' ==UT==LABEL-VERIFY-COMPARE
-                      ==UT==EXPECTED-ACCESSES-FMT SPACE
-                      ==UT==LABEL-EXPECTED-ACCESS ' '
-                      'TO ' ==UT==MOCK-OPERATION
+               STRING
+                    ==UT==PASSED   DELIMITED BY SIZE
+                    ==UT==TEST-CASE-NUMBER '. ' DELIMITED BY SIZE
+                    'VERIFY ' ==UT==LABEL-VERIFY-COMPARE DELIMITED BY '  '
+                    ' ' DELIMITED BY SIZE
+                    ==UT==EXPECTED-ACCESSES-DISP DELIMITED BY SPACE
+                    ' ' DELIMITED BY SIZE
+                    ==UT==LABEL-EXPECTED-ACCESS ' ' DELIMITED BY SIZE
+                    'TO ' ==UT==MOCK-OPERATION DELIMITED BY SIZE
+                   INTO ==UT==DISPLAY-MESSAGE
+               END-STRING
+               DISPLAY ==UT==DISPLAY-MESSAGE
 
            ELSE
                ADD 1 TO ==UT==NUMBER-FAILED
@@ -198,12 +211,13 @@
                MOVE SPACES TO ==UT==DISPLAY-MESSAGE
                STRING
                    '   EXPECTED '                 DELIMITED BY SIZE
-                   ==UT==LABEL-VERIFY-COMPARE ' ' DELIMITED BY SIZE
-                   ==UT==EXPECTED-ACCESSES-FMT       DELIMITED BY SIZE
-                   SPACE                          DELIMITED BY SIZE
+                   ==UT==LABEL-VERIFY-COMPARE DELIMITED BY '  '
+                   ' ' DELIMITED BY SIZE
+                   ==UT==EXPECTED-ACCESSES-DISP       DELIMITED BY SPACE
+                   ' '                          DELIMITED BY SIZE
                    ==UT==LABEL-EXPECTED-ACCESS       DELIMITED BY SPACE
                    ', WAS '                       DELIMITED BY SIZE
-                   ==UT==ACTUAL-ACCESSES-FMT         DELIMITED BY SIZE
+                   ==UT==ACTUAL-ACCESSES-DISP         DELIMITED BY SIZE
                    INTO ==UT==DISPLAY-MESSAGE
                END-STRING
                DISPLAY ==UT==DISPLAY-MESSAGE

--- a/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKWS.CPY
+++ b/src/main/resources/org/openmainframeproject/cobolcheck/copybooks/CCHECKWS.CPY
@@ -51,10 +51,12 @@
                88 ==UT==EXPECTED-88-VALUE             VALUE 'T', FALSE 'F'.
            05  FILLER                    PIC X     VALUE 'F'.
                88 ==UT==ACTUAL-88-VALUE               VALUE 'T', FALSE 'F'.
-           05  ==UT==EXPECTED-ACCESSES      PIC 9(04) VALUE ZERO.
-           05  ==UT==ACTUAL-ACCESSES        PIC 9(04) VALUE ZERO.
-           05  ==UT==EXPECTED-ACCESSES-FMT  PIC Z,ZZ9.
-           05  ==UT==ACTUAL-ACCESSES-FMT    PIC Z,ZZ9.
+           05  ==UT==EXPECTED-ACCESSES      PIC 9(18) VALUE ZERO.
+           05  ==UT==ACTUAL-ACCESSES        PIC 9(18) VALUE ZERO.
+           05  ==UT==EXPECTED-ACCESSES-FMT  PIC ZZZ,ZZZ,ZZZ,ZZZ,ZZZ,ZZ9.
+           05  ==UT==ACTUAL-ACCESSES-FMT    PIC ZZZ,ZZZ,ZZZ,ZZZ,ZZZ,ZZ9.
+           05  ==UT==EXPECTED-ACCESSES-DISP PIC X(18).
+           05  ==UT==ACTUAL-ACCESSES-DISP   PIC X(18).
            05  ==UT==FAILED                 PIC X(11)  VALUE "**** FAIL: ".
            05  ==UT==PASSED                 PIC X(11)  VALUE "     PASS: ".
            05  ==UT==TEST-SUITE-NAME        PIC X(80)  VALUE SPACES.

--- a/src/test/cobol/MOCKTEST/MockCallTest.cut
+++ b/src/test/cobol/MOCKTEST/MockCallTest.cut
@@ -9,14 +9,6 @@
                 MOVE "Global PROG1" TO VALUE-1
            END-MOCK
 
-           MOCK SECTION 850-ONLY-CALL
-                MOVE "SUCCESS" TO VALUE-1
-           END-MOCK
-
-           MOCK SECTION 999-TEST
-                CONTINUE
-           END-MOCK
-
            TestCase "Simple call mock works"
            MOCK CALL 'PROG1'
                 MOVE "From mocked PROG1" TO VALUE-1
@@ -97,12 +89,3 @@
            END-MOCK
            PERFORM 600-MAKE-CALL
            EXPECT VALUE-1 TO BE "Global PROG1"
-
-           TESTCASE "Section with only a call can be mocked"
-           PERFORM 850-ONLY-CALL
-           EXPECT VALUE-1 TO BE "SUCCESS"
-
-           TESTSUITE "Just testing"
-           TESTCASE "Section with only a call can be mocked 2 (Should fail)"
-           PERFORM 850-ONLY-CALL
-           EXPECT VALUE-1 TO BE "SUCCESS"

--- a/src/test/cobol/MOCKTEST/MockCallTest.cut
+++ b/src/test/cobol/MOCKTEST/MockCallTest.cut
@@ -1,7 +1,20 @@
+      * Test for mocking call statements
+      * Writing a comment to test stuff
+      *
+      *Yeah
+      *
            TestSuite "Mock Call statements test"
 
            MOCK CALL 'PROG1'
                 MOVE "Global PROG1" TO VALUE-1
+           END-MOCK
+
+           MOCK SECTION 850-ONLY-CALL
+                MOVE "SUCCESS" TO VALUE-1
+           END-MOCK
+
+           MOCK SECTION 999-TEST
+                CONTINUE
            END-MOCK
 
            TestCase "Simple call mock works"
@@ -29,6 +42,11 @@
            VERIFY CALL VALUE-2 USING VALUE-1
                 HAPPENED ONCE
 
+      * Test for mocking call statements
+      * Writing a comment to test stuff
+      *
+      *Yeah
+      *
            TestCase "Call mock with content reference for arguments work"
            MOCK CALL 'PROG3' USING
              BY CONTENT VALUE-1,
@@ -79,3 +97,12 @@
            END-MOCK
            PERFORM 600-MAKE-CALL
            EXPECT VALUE-1 TO BE "Global PROG1"
+
+           TESTCASE "Section with only a call can be mocked"
+           PERFORM 850-ONLY-CALL
+           EXPECT VALUE-1 TO BE "SUCCESS"
+
+           TESTSUITE "Just testing"
+           TESTCASE "Section with only a call can be mocked 2 (Should fail)"
+           PERFORM 850-ONLY-CALL
+           EXPECT VALUE-1 TO BE "SUCCESS"

--- a/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/InterpreterControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -741,11 +742,105 @@ public class InterpreterControllerTest {
                 interpreterController.getNumericFieldDataTypeFor("WS-COUNT").name());
     }
 
+    @Test
+    public void it_registers_EXEC_SQL_as_stub() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "       851-PLACEHOLDER SECTION.";
+        String str3 = "           EXEC SQL";
+        String str4 = "               OPEN SQL-RELATED-STUFF";
+        String str5 = "               CREATE TABLE 'Hi'";
+        String str6 = "               EXIT SECTION";
+        String str7 = "";
+        String str8 = "      *Basically anything can be inside EXEC body, Cobol Check does not care";
+        String str9 = "           END-EXEC";
+        String str10 = "           .";
 
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, str7, str8, str9, str10, null);
 
+        List<String> expectedStubbedStatement = Arrays.asList(str3, str4, str5, str6, str7, str8, str9);
+        boolean testsRan = false;
+        String currentLine = "";
+        while (currentLine != null){
+            currentLine = interpreterController.interpretNextLine();
+            if (currentLine != null && currentLine.contains("END-EXEC")){
+                assertTrue(interpreterController.shouldCurrentStatementBeStubbed());
+                assertEquals(interpreterController.getCurrentStatement(), expectedStubbedStatement);
+                testsRan = true;
+            }
+        }
+        assertTrue(testsRan);
+    }
 
+    @Test
+    public void it_handles_empty_sql_exec() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "       851-PLACEHOLDER SECTION.";
+        String str3 = "           EXEC SQL";
+        String str4 = "           END-EXEC";
+        String str5 = "           .";
 
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
 
+        List<String> expectedStubbedStatement = Arrays.asList(str3, str4);
+        boolean testsRan = false;
+        String currentLine = "";
+        while (currentLine != null){
+            currentLine = interpreterController.interpretNextLine();
+            if (currentLine != null && currentLine.contains("END-EXEC")){
+                assertTrue(interpreterController.shouldCurrentStatementBeStubbed());
+                assertEquals(interpreterController.getCurrentStatement(), expectedStubbedStatement);
+                testsRan = true;
+            }
+        }
+        assertTrue(testsRan);
+    }
+
+    @Test
+    public void it_handles_empty_sql_exec_one_liner() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "       851-PLACEHOLDER SECTION.";
+        String str3 = "           EXEC SQL  END-EXEC";
+        String str4 = "           .";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, null);
+
+        List<String> expectedStubbedStatement = Arrays.asList(str3);
+        boolean testsRan = false;
+        String currentLine = "";
+        while (currentLine != null){
+            currentLine = interpreterController.interpretNextLine();
+            if (currentLine != null && currentLine.contains("END-EXEC")){
+                assertTrue(interpreterController.shouldCurrentStatementBeStubbed());
+                assertEquals(interpreterController.getCurrentStatement(), expectedStubbedStatement);
+                testsRan = true;
+            }
+        }
+        assertTrue(testsRan);
+    }
+
+    @Test
+    public void it_registers_EXEC_CICS_as_stub() throws IOException {
+        String str1 = "       PROCEDURE DIVISION.";
+        String str2 = "       851-PLACEHOLDER SECTION.";
+        String str3 = "           EXEC CICS";
+        String str4 = "               OPEN CICS-RELATED-STUFF";
+        String str5 = "           END-EXEC.";
+
+        Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, null);
+
+        List<String> expectedStubbedStatement = Arrays.asList(str3, str4, str5);
+        boolean testsRan = false;
+        String currentLine = "";
+        while (currentLine != null){
+            currentLine = interpreterController.interpretNextLine();
+            if (currentLine != null && currentLine.contains("END-EXEC")){
+                assertTrue(interpreterController.shouldCurrentStatementBeStubbed());
+                assertEquals(interpreterController.getCurrentStatement(), expectedStubbedStatement);
+                testsRan = true;
+            }
+        }
+        assertTrue(testsRan);
+    }
 
 
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
@@ -246,8 +246,8 @@ public class MockIT {
     private String expected1 =
             "       WORKING-STORAGE SECTION.                                                 " + Constants.NEWLINE +
                     "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-                    "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-                    "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+                    "           05  UT-1-0-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+                    "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
                     "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
                     "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
                     "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
@@ -304,24 +304,24 @@ public class MockIT {
     private String expected2 =
             "       WORKING-STORAGE SECTION.                                                 " +      Constants.NEWLINE  +
             "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-1-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 100-WELCOME\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-3-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
             "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
@@ -521,28 +521,28 @@ public class MockIT {
     private String expected4 =
             "       WORKING-STORAGE SECTION.                                                 " +     Constants.NEWLINE +
             "       01  UT-MOCKS-GENERATED.                                                  " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 100-WELCOME\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-0-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-0-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-0-2-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-0-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"CALL 'prog2'\".                                        " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-1-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-1-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 000-START\".                                   " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-2-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-2-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"CALL 'prog1'\".                                        " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
-            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
+            "           05  UT-1-2-3-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.             " + Constants.NEWLINE +
             "           05  UT-1-2-3-MOCK-NAME        PIC X(40)                              " + Constants.NEWLINE +
             "                   VALUE \"SECTION 200-GOODBYE\".                                 " + Constants.NEWLINE +
             "       PROCEDURE DIVISION.                                                      " + Constants.NEWLINE +
@@ -682,6 +682,7 @@ public class MockIT {
             "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "      *    CALL 'prog1' USING BY CONTENT VALUE-1, VALUE-2.                      " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -703,6 +704,7 @@ public class MockIT {
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "          MOVE \"Bye\" to VALUE-1                                                 " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1                                            " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
@@ -710,6 +712,7 @@ public class MockIT {
             "                    PERFORM UT-1-0-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1.                                           " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
@@ -166,9 +166,12 @@ public class MockIT {
         String s9 = "           MOVE \"Hello\" to VALUE-1.";
         String s10 = "       200-GOODBYE SECTION.";
         String s11 = "          MOVE \"Bye\" to VALUE-1";
-        String s12 = "          CALL 'prog2' USING VALUE-1";
-        String s13 = "          CALL 'prog2' USING VALUE-1.";
-        String s14 = "          .";
+        String s12 = "          CALL bogus USING VALUE-1";
+        String s13 = "";
+        String s14 = "          CALL 'prog2' USING VALUE-1";
+        String s15 = "          CALL 'prog2' USING VALUE-1.";
+        String s16 = "          .";
+        String s17 = "      * Ending with comment";
 
         String t1 = "           TestSuite \"Mocking tests\"";
         String t2 = "           MOCK SECTION 100-WELCOME";
@@ -192,7 +195,7 @@ public class MockIT {
         String t20 = "           END-MOCK";
 
         Mockito.when(mockedInterpreterReader.readLine()).thenReturn(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10,
-                s11, s12, s13, s14, null);
+                s11, s12, s13, s14, s15, s16, s17, null);
         Mockito.when(mockedParserReader.readLine()).thenReturn(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11,
                 t12, t13, t14, t15, t16, t17, t18, t19, t20, null);
 
@@ -682,13 +685,13 @@ public class MockIT {
             "                    PERFORM UT-1-0-1-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "      *    CALL 'prog1' USING BY CONTENT VALUE-1, VALUE-2.                      " + Constants.NEWLINE +
-            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO \"Simply a test\"                                         " + Constants.NEWLINE +
             "                    PERFORM UT-1-2-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "           MOVE \"Hello\" to VALUE-1                                              " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
             "           .                                                                    " + Constants.NEWLINE +
@@ -703,24 +706,28 @@ public class MockIT {
             "                    PERFORM UT-1-2-3-MOCK                                          " + Constants.NEWLINE +
             "           WHEN OTHER                                                           " + Constants.NEWLINE +
             "          MOVE \"Bye\" to VALUE-1                                                 " + Constants.NEWLINE +
+            "      *   CALL bogus USING VALUE-1                                              " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
+            "                                                                                " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1                                            " + Constants.NEWLINE +
-            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
             "                    PERFORM UT-1-0-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "      *   CALL 'prog2' USING VALUE-1.                                           " + Constants.NEWLINE +
-            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            EVALUATE UT-TEST-SUITE-NAME                                         " + Constants.NEWLINE +
             "                   ALSO UT-TEST-CASE-NAME                                       " + Constants.NEWLINE +
             "                WHEN \"Mocking tests\"                                            " + Constants.NEWLINE +
             "                   ALSO ANY                                                     " + Constants.NEWLINE +
             "                    PERFORM UT-1-0-2-MOCK                                          " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
+            "            CONTINUE                                                            " + Constants.NEWLINE +
             "            END-EVALUATE                                                        " + Constants.NEWLINE +
-            "          .                                                                    ";
+            "          .                                                                    " + Constants.NEWLINE +
+            "      * Ending with comment                                                    ";
 
 }
 

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
@@ -807,8 +807,8 @@ public class MockingTest {
 
         List<String> expected = new ArrayList<>();
         expected.add("       01  UT-MOCKS-GENERATED.");
-        expected.add("           05  UT-1-1-1-MOCK-COUNT       PIC 9(02) VALUE ZERO COMP.");
-        expected.add("           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(02) VALUE ZERO COMP.");
+        expected.add("           05  UT-1-1-1-MOCK-COUNT       PIC 9(18) VALUE ZERO COMP.");
+        expected.add("           05  UT-1-1-1-MOCK-EXPECTED    PIC 9(18) VALUE ZERO COMP.");
         expected.add("           05  UT-1-1-1-MOCK-NAME        PIC X(40)");
         expected.add("                   VALUE \"SECTION 000-START\".");
 


### PR DESCRIPTION
- Fixed mock count not being able t exceed 99. Now it can count up to 999,999,999,999,999,999. Added text formatting for this.
- Adding stubbing for EXEC SQL and EXEC CICS
- Fixed bug where a stub followed by empty line would throw exception
- Fixed file ending with mock followed by comment not being generated properly
- Fixed Continue and period not being generated properly for stubs in some instances
- Minor refactoring
- Added tests for fixed bugs