### PR TITLE
Fixed minor bug in error messages

### DIFF
--- a/vs code extension/client/src/Helpers/PathHelper.ts
+++ b/vs code extension/client/src/Helpers/PathHelper.ts
@@ -12,3 +12,11 @@ export function endsPath(path:string) : boolean{
 			path.endsWith(".cbl") || (path.endsWith(":") && path.includes(".cbl")) || 
 			path.endsWith(".CBL:") || (path.endsWith(":") && path.includes(".CBL:")));
 }
+
+export function startsWithPath(value:string) : boolean{
+	let words = value.split(' ');
+	if (words.length > 0)
+		return couldBePath(words[0])
+	else
+		return false;
+}


### PR DESCRIPTION
Fixed bug where a warning and a COBOL compile error in the log, would simply be shown as a warning. Now it will be shown as a compile error.