### PR TITLE
String continuation bug fixed

### DIFF
--- a/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/writer/CobolWriter.java
@@ -173,8 +173,16 @@ public class CobolWriter {
             }
             else {
                 //Continue line at applicable space (line is split neither during string nor comment)
-                String[] words = line.trim().split(" ");
-                if (isRecursiveCall)
+                String[] words = null;
+                if (StringHelper.isStringContinuationLine(line)){
+                    words = line.substring(11).trim().split(" ");
+                }
+                else{
+                    words = line.trim().split(" ");
+                }
+                if (StringHelper.isStringContinuationLine(line))
+                    line1 = "      -    ";
+                else if (isRecursiveCall)
                     line1 = "               ";
                 else
                     line1 = "           ";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
@@ -211,6 +211,10 @@ public class StringHelper {
         return output;
     }
 
+    public static boolean isStringContinuationLine(String line) {
+        return line.startsWith("      -    '") || line.startsWith("      -    \"");
+    }
+
     /**
      * Enclose a value in quotation marks.
      *

--- a/src/test/java/org/openmainframeproject/cobolcheck/writerTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/writerTest.java
@@ -92,6 +92,21 @@ public class writerTest {
         assertEquals(expectedLine1 + expectedLine2 + expectedLine3 + expectedLine4, writer.toString());
     }
 
+
+    @Test
+    void it_formats_a_Cobol_continuation_line_based_on_a_string_continuation_followed_by_split_at_cobol_token() throws IOException {
+        String originalText = "            MOVE FUNCTION DISPLAY-OF( FUNCTION NATIONAL-OF('{\"MESSAGEDATA\": {\"EVENTID\":\"823\",\"EXDATE\":\"2022-06-21\"}}'" +
+                "      , 819), 1208) to WS-MESSAGE";
+        String expectedLine1 = "            MOVE FUNCTION DISPLAY-OF( FUNCTION NATIONAL-OF('{\"MESSAGEDAT        ";
+        expectedLine1 += Constants.NEWLINE;
+        String expectedLine2 = "      -    'A\": {\"EVENTID\":\"823\",\"EXDATE\":\"2022-06-21\"}}'      , 819),          ";
+        expectedLine2 += Constants.NEWLINE;
+        String expectedLine3 = "               1208) to WS-MESSAGE                                              ";
+        expectedLine3 += Constants.NEWLINE;
+        writerController.writeLine(originalText);
+        assertEquals(expectedLine1 + expectedLine2 + expectedLine3, writer.toString());
+    }
+
     @Test
     void it_formats_a_long_Cobol_comment_into_3_lines() throws IOException {
         String originalText = "      * This comment is so loooooooooooooooooooooooooooooooooooooooooooo" +


### PR DESCRIPTION
Fixed bug where a string continuation line, would be at the wrong column, if followed by another line that is too long, that needs to be split during regular code elements.

Signed-off-by: David Kaan <dak@bankdata.dk>