### PR TITLE
Improved syntax check with context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ ext {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_9
+    targetCompatibility = JavaVersion.VERSION_1_9
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ ext {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_9
-    targetCompatibility = JavaVersion.VERSION_1_9
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {

--- a/src/main/cobol/MOCKTEST.CBL
+++ b/src/main/cobol/MOCKTEST.CBL
@@ -84,6 +84,7 @@
            MOVE "arg1" to VALUE-1
            MOVE "arg2" to VALUE-2
            CALL VALUE-2 USING VALUE-1
+           CALL VALUE-2
            END-CALL.
 
        800-MAKE-CALL.

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/Formatter/Formats/HTMLFormat.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/launcher/Formatter/Formats/HTMLFormat.java
@@ -1,7 +1,4 @@
 package org.openmainframeproject.cobolcheck.features.launcher.Formatter.Formats;
-
-import com.sun.org.apache.xalan.internal.xsltc.compiler.util.ErrorMsg;
-import com.sun.org.apache.xalan.internal.xsltc.compiler.util.TypeCheckError;
 import org.openmainframeproject.cobolcheck.features.launcher.Formatter.DataTransferObjects.DataTransferObject;
 import org.openmainframeproject.cobolcheck.features.launcher.Formatter.DataTransferObjects.DataTransferObjectStyle;
 import org.openmainframeproject.cobolcheck.services.filehelpers.EncodingIO;
@@ -17,7 +14,7 @@ public class HTMLFormat extends Formatter{
     }
 
     @Override
-    public String writeInFormat(String path) throws IOException, TypeCheckError {
+    public String writeInFormat(String path) throws IOException, IncompatibleClassChangeError {
         Object dataTransferObject = this.dataTransferObject.getDataTransferObject();
         if (dataTransferObject instanceof String){
             String HTMLText = (String)dataTransferObject;
@@ -26,7 +23,7 @@ public class HTMLFormat extends Formatter{
             writer.close();
             return HTMLText;
         }
-        throw new TypeCheckError(new ErrorMsg("Type of Data Transfer Object when writing HTML, must be <String>, " +
-                "however; the given object could not be parsed as a String."));
+        throw new IncompatibleClassChangeError("Type of Data Transfer Object when writing HTML, must be <String>, " +
+                "however; the given object could not be parsed as a String.");
     }
 }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -2,16 +2,18 @@ package org.openmainframeproject.cobolcheck.features.testSuiteParser;
 
 import org.openmainframeproject.cobolcheck.services.Constants;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ContextHandler {
     private static String currentContext;
-    private static Map<String, String> startAndEndOfContexts;
+    private static Map<String, List<String>> startAndEndOfContexts;
 
     static {
         startAndEndOfContexts = new HashMap<>();
-        startAndEndOfContexts.put(Constants.MOCK_KEYWORD, Constants.ENDMOCK_KEYWORD);
+        startAndEndOfContexts.put(Constants.MOCK_KEYWORD,  Arrays.asList(Constants.ENDMOCK_KEYWORD));
     }
 
     public static void tryEnterContext(String keyword){
@@ -21,7 +23,7 @@ public class ContextHandler {
     }
 
     public static void tryExitingContext(String keyword){
-        if (insideOfContext() && keyword == getContextEndKey()){
+        if (insideOfContext() && doesKeyEndContext(keyword)){
             currentContext = null;
         }
     }
@@ -33,11 +35,17 @@ public class ContextHandler {
     }
 
     public static String getCurrentContext() { return currentContext; }
-    public static String getContextEndKey() {
-        if (insideOfContext())
-            return startAndEndOfContexts.get(currentContext);
+    public static boolean doesKeyEndContext(String key) {
+        if (insideOfContext()){
+            for (String endKey : startAndEndOfContexts.get(currentContext)){
+                if (key.equals(endKey))
+                    return true;
+            }
+            return false;
+        }
+
         else
-            return null;
+            return false;
 
 
     }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -18,10 +18,15 @@ public class ContextHandler {
         if (!insideOfContext() && startAndEndOfContexts.containsKey(keyword)){
             currentContext = keyword;
         }
-        else if (insideOfContext() && keyword == getContextEndKey()){
+    }
+
+    public static void tryExitingContext(String keyword){
+        if (insideOfContext() && keyword == getContextEndKey()){
             currentContext = null;
         }
     }
+
+
 
     public static boolean insideOfContext(){
         return currentContext != null;

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -9,12 +9,14 @@ import java.util.Map;
 
 public class ContextHandler {
     private static String currentContext;
+    private static Keyword keyword;
     private static Map<String, List<String>> startAndEndOfContexts;
 
     static {
         startAndEndOfContexts = new HashMap<>();
         startAndEndOfContexts.put(Constants.MOCK_KEYWORD,  Arrays.asList(Constants.ENDMOCK_KEYWORD));
         startAndEndOfContexts.put(Constants.EXPECT_KEYWORD,  Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD, Constants.BOOLEAN_VALUE));
+        startAndEndOfContexts.put(Constants.VERIFY_KEYWORD,  Arrays.asList(Constants.ONCE_KEYWORD, Constants.TIMES_KEYWORD, Constants.NEVER_HAPPENED_KEYWORD, Constants.USING_TOKEN));
     }
 
     public static void tryEnterContext(String keyword){
@@ -39,7 +41,8 @@ public class ContextHandler {
     public static boolean doesKeyEndContext(String key) {
         if (insideOfContext()){
             for (String endKey : startAndEndOfContexts.get(currentContext)){
-                if (key.equals(endKey) || (key.startsWith(Constants.QUOTE) && key.endsWith(Constants.QUOTE)))
+                keyword = Keywords.getKeywordFor(key, true);
+                if (keyword.value().equals(endKey))
                     return true;
             }
             return false;

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -39,7 +39,7 @@ public class ContextHandler {
     public static boolean doesKeyEndContext(String key) {
         if (insideOfContext()){
             for (String endKey : startAndEndOfContexts.get(currentContext)){
-                if (key.equals(endKey))
+                if (key.equals(endKey) || (key.startsWith(Constants.QUOTE) && key.endsWith(Constants.QUOTE)))
                     return true;
             }
             return false;

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -14,6 +14,7 @@ public class ContextHandler {
     static {
         startAndEndOfContexts = new HashMap<>();
         startAndEndOfContexts.put(Constants.MOCK_KEYWORD,  Arrays.asList(Constants.ENDMOCK_KEYWORD));
+        startAndEndOfContexts.put(Constants.EXPECT_KEYWORD,  Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD, Constants.BOOLEAN_VALUE));
     }
 
     public static void tryEnterContext(String keyword){

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -16,7 +16,7 @@ public class ContextHandler {
         startAndEndOfContexts = new HashMap<>();
         startAndEndOfContexts.put(Constants.MOCK_KEYWORD,  Arrays.asList(Constants.ENDMOCK_KEYWORD));
         startAndEndOfContexts.put(Constants.EXPECT_KEYWORD,  Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD, Constants.BOOLEAN_VALUE));
-        startAndEndOfContexts.put(Constants.VERIFY_KEYWORD,  Arrays.asList(Constants.ONCE_KEYWORD, Constants.TIMES_KEYWORD, Constants.NEVER_HAPPENED_KEYWORD, Constants.USING_TOKEN));
+        startAndEndOfContexts.put(Constants.VERIFY_KEYWORD,  Arrays.asList(Constants.ONCE_KEYWORD, Constants.TIMES_KEYWORD, Constants.NEVER_HAPPENED_KEYWORD, Constants.TIME_KEYWORD));
     }
 
     public static void tryEnterContext(String keyword){
@@ -29,6 +29,11 @@ public class ContextHandler {
         if (insideOfContext() && doesKeyEndContext(keyword)){
             currentContext = null;
         }
+    }
+
+    //Used only for testing
+    public static void forceContextExit(){
+        currentContext = null;
     }
 
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/ContextHandler.java
@@ -1,0 +1,40 @@
+package org.openmainframeproject.cobolcheck.features.testSuiteParser;
+
+import org.openmainframeproject.cobolcheck.services.Constants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ContextHandler {
+    private static String currentContext;
+    private static Map<String, String> startAndEndOfContexts;
+
+    static {
+        startAndEndOfContexts = new HashMap<>();
+        startAndEndOfContexts.put(Constants.MOCK_KEYWORD, Constants.ENDMOCK_KEYWORD);
+    }
+
+    public static void tryEnterContext(String keyword){
+        if (!insideOfContext() && startAndEndOfContexts.containsKey(keyword)){
+            currentContext = keyword;
+        }
+        else if (insideOfContext() && keyword == getContextEndKey()){
+            currentContext = null;
+        }
+    }
+
+    public static boolean insideOfContext(){
+        return currentContext != null;
+    }
+
+    public static String getCurrentContext() { return currentContext; }
+    public static String getContextEndKey() {
+        if (insideOfContext())
+            return startAndEndOfContexts.get(currentContext);
+        else
+            return null;
+
+
+    }
+
+}

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
@@ -1,6 +1,7 @@
 package org.openmainframeproject.cobolcheck.features.testSuiteParser;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class encapsulates information about a Cobol Check keyword.
@@ -15,13 +16,21 @@ import java.util.List;
 public class Keyword {
     private final String value;
     private final List<String> validNextKeys;
+    private final Map<String, List<String>> validNextKeysInContext;
     private final KeywordAction keywordAction;
 
-    public Keyword(String value,
-                   List<String> validNextKeys,
+    public Keyword(String value, List<String> validNextKeys, KeywordAction keywordAction) {
+        this.value = value;
+        this.validNextKeys = validNextKeys;
+        this.validNextKeysInContext = null;
+        this.keywordAction = keywordAction;
+    }
+
+    public Keyword(String value, List<String> validNextKeys, Map<String, List<String>> validNextKeysInContext,
                    KeywordAction keywordAction) {
         this.value = value;
         this.validNextKeys = validNextKeys;
+        this.validNextKeysInContext = validNextKeysInContext;
         this.keywordAction = keywordAction;
     }
 
@@ -29,8 +38,16 @@ public class Keyword {
         return value;
     }
 
-    public List<String> getvalidNextKeys() {
-        return validNextKeys;
+    public List<String> getvalidNextKeys(String context) {
+        if (validNextKeysInContext == null || context == null || context.isEmpty()){
+            return validNextKeys;
+        }
+        else {
+            if (validNextKeysInContext.containsKey(context))
+                return validNextKeysInContext.get(context);
+            else
+                return validNextKeys;
+        }
     }
 
     public KeywordAction keywordAction() {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
@@ -39,7 +39,7 @@ public class Keyword {
         return value;
     }
 
-    public List<String> getvalidNextKeys(String context) {
+    public List<String> getValidNextKeys(String context) {
         if (context == null || context.isEmpty()){
             return validNextKeys;
         }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keyword.java
@@ -1,5 +1,6 @@
 package org.openmainframeproject.cobolcheck.features.testSuiteParser;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -39,14 +40,16 @@ public class Keyword {
     }
 
     public List<String> getvalidNextKeys(String context) {
-        if (validNextKeysInContext == null || context == null || context.isEmpty()){
+        if (context == null || context.isEmpty()){
             return validNextKeys;
         }
+        else if (validNextKeysInContext == null)
+            return new ArrayList<>();
         else {
             if (validNextKeysInContext.containsKey(context))
                 return validNextKeysInContext.get(context);
             else
-                return validNextKeys;
+                return new ArrayList<>();
         }
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -5,6 +5,8 @@ import org.openmainframeproject.cobolcheck.services.log.Log;
 
 import java.util.*;
 
+import static java.util.Map.entry;
+
 /**
  * This is a container for Keyword records. It is used when parsing test suites to identify cobol-check
  * keywords and handle them appropriately.
@@ -18,18 +20,25 @@ public class Keywords {
 
     static {
         keywordInfo = new HashMap<>();
+        //--------------------------------TESTSUITE
         keywordInfo.put(Constants.TESTSUITE_KEYWORD,
                 new Keyword(Constants.TESTSUITE_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD),
-                        KeywordAction.TESTSUITE_NAME));
+                    KeywordAction.TESTSUITE_NAME));
+
+        //--------------------------------TESTCASE
         keywordInfo.put(Constants.TESTCASE_KEYWORD,
                 new Keyword(Constants.TESTCASE_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD),
-                        KeywordAction.NEW_TESTCASE));
+                    KeywordAction.NEW_TESTCASE));
+
+        //--------------------------------EXPECT
         keywordInfo.put(Constants.EXPECT_KEYWORD,
                 new Keyword(Constants.EXPECT_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
-                        KeywordAction.ACTUAL_FIELDNAME));
+                    KeywordAction.ACTUAL_FIELDNAME));
+
+        //--------------------------------FIELD NAME
         keywordInfo.put(Constants.FIELDNAME_KEYWORD,
                 new Keyword(Constants.FIELDNAME_KEYWORD,
                         Arrays.asList(Constants.TO_BE_KEYWORD,
@@ -43,15 +52,22 @@ public class Keywords {
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
-                                Constants.USING_TOKEN,
                                 Constants.COBOL_TOKEN,
                                 Constants.FIELDNAME_KEYWORD,
-                                Constants.BY_REFERENCE_TOKEN,
-                                Constants.BY_CONTENT_TOKEN,
-                                Constants.BY_VALUE_TOKEN,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
-                                Constants.ENDMOCK_KEYWORD),
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
+                                Map.ofEntries(
+                                        entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                                Constants.ENDMOCK_KEYWORD,
+                                                Constants.FIELDNAME_KEYWORD,
+                                                Constants.BY_REFERENCE_TOKEN,
+                                                Constants.BY_CONTENT_TOKEN,
+                                                Constants.BY_VALUE_TOKEN,
+                                                Constants.USING_TOKEN
+                                                ))
+                                        ),
                         KeywordAction.FIELDNAME));
+
+        //--------------------------------NOT
         keywordInfo.put(Constants.NOT_KEYWORD,
                 new Keyword(Constants.NOT_KEYWORD,
                         Arrays.asList(Constants.TO_BE_KEYWORD,
@@ -63,6 +79,8 @@ public class Keywords {
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD),
                         KeywordAction.REVERSE_LOGIC));
+
+        //--------------------------------NOT EQUAL SIGN
         keywordInfo.put(Constants.NOT_EQUAL_SIGN_KEYWORD,
                 new Keyword(Constants.NOT_EQUAL_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -71,6 +89,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.REVERSE_LOGIC));
+
+        //--------------------------------TO BE
         keywordInfo.put(Constants.TO_BE_KEYWORD,
                 new Keyword(Constants.TO_BE_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -79,6 +99,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------TO EQUAL
         keywordInfo.put(Constants.TO_EQUAL_KEYWORD,
                 new Keyword(Constants.TO_EQUAL_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -87,6 +109,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------EQUAL SIGN
         keywordInfo.put(Constants.EQUAL_SIGN_KEYWORD,
                 new Keyword(Constants.EQUAL_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -95,6 +119,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------GREATER THAN SIGN
         keywordInfo.put(Constants.GREATER_THAN_SIGN_KEYWORD,
                 new Keyword(Constants.GREATER_THAN_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -103,6 +129,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------GREATER THAN EQUAL TO SIGN
         keywordInfo.put(Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                 new Keyword(Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -111,6 +139,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------LESS THAN SIGN
         keywordInfo.put(Constants.LESS_THAN_SIGN_KEYWORD,
                 new Keyword(Constants.LESS_THAN_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -119,6 +149,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------LESS THAN EQUAL TO SIGN
         keywordInfo.put(Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                 new Keyword(Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -127,6 +159,8 @@ public class Keywords {
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE));
+
+        //--------------------------------PARENTHESIS-ENCLOSED
         keywordInfo.put(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                 new Keyword(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                         Arrays.asList(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
@@ -146,6 +180,8 @@ public class Keywords {
                                 Constants.VERIFY_KEYWORD,
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.COBOL_STATEMENT));
+
+        //--------------------------------ALPHANUMERIC LITERAL
         keywordInfo.put(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                 new Keyword(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
@@ -164,6 +200,8 @@ public class Keywords {
                                 Constants.USING_TOKEN,
                                 Constants.ENDMOCK_KEYWORD),
                         KeywordAction.FIELDNAME));
+
+        //--------------------------------NUMERIC LITERAL
         keywordInfo.put(Constants.NUMERIC_LITERAL_KEYWORD,
                 new Keyword(Constants.NUMERIC_LITERAL_KEYWORD,
                         Arrays.asList(Constants.EXPECT_KEYWORD,
@@ -175,7 +213,8 @@ public class Keywords {
                                 Constants.TIME_KEYWORD,
                                 Constants.TIMES_KEYWORD),
                         KeywordAction.FIELDNAME));
-        //TODO HERE
+
+        //--------------------------------COBOL TOKEN
         keywordInfo.put(Constants.COBOL_TOKEN,
                 new Keyword(Constants.COBOL_TOKEN,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
@@ -199,6 +238,8 @@ public class Keywords {
                                 Constants.TIME_KEYWORD,
                                 Constants.TIMES_KEYWORD),
                         KeywordAction.COBOL_STATEMENT));
+
+        //--------------------------------BOOLEAN VALUE
         keywordInfo.put(Constants.BOOLEAN_VALUE,
                 new Keyword(Constants.BOOLEAN_VALUE,
                         Arrays.asList(Constants.EXPECT_KEYWORD,
@@ -208,10 +249,14 @@ public class Keywords {
                                 Constants.MOCK_KEYWORD,
                                 Constants.VERIFY_KEYWORD),
                         KeywordAction.BOOLEAN_COMPARE));
+
+        //--------------------------------BEFORE EACH
         keywordInfo.put(Constants.BEFORE_EACH_TOKEN,
                 new Keyword(Constants.BEFORE_EACH_TOKEN,
                         Arrays.asList(Constants.END_BEFORE_TOKEN),
                         KeywordAction.NONE));
+
+        //--------------------------------END BEFORE
         keywordInfo.put(Constants.END_BEFORE_TOKEN,
                 new Keyword(Constants.END_BEFORE_TOKEN,
                         Arrays.asList(Constants.AFTER_EACH_TOKEN,
@@ -220,10 +265,14 @@ public class Keywords {
                                 Constants.TESTCASE_KEYWORD,
                                 Constants.MOCK_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------AFTER EACH
         keywordInfo.put(Constants.AFTER_EACH_TOKEN,
                 new Keyword(Constants.AFTER_EACH_TOKEN,
                         Arrays.asList(Constants.END_AFTER_TOKEN),
                         KeywordAction.NONE));
+
+        //--------------------------------END AFTER
         keywordInfo.put(Constants.END_AFTER_TOKEN,
                 new Keyword(Constants.END_AFTER_TOKEN,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -233,19 +282,27 @@ public class Keywords {
                                 Constants.TESTCASE_KEYWORD,
                                 Constants.MOCK_KEYWORD),
                         KeywordAction.NONE));
+
         //TODO: Remove hyphen keyword option? Backwards compatibility
+        //--------------------------------BEFORE-EACH
         keywordInfo.put(Constants.BEFORE_EACH_TOKEN_HYPHEN,
                 new Keyword(Constants.BEFORE_EACH_TOKEN_HYPHEN,
                         Arrays.asList(Constants.END_BEFORE_TOKEN),
                         KeywordAction.NONE));
+
+        //--------------------------------AFTER-EACH
         keywordInfo.put(Constants.AFTER_EACH_TOKEN_HYPHEN,
                 new Keyword(Constants.AFTER_EACH_TOKEN_HYPHEN,
                         Arrays.asList(Constants.END_AFTER_TOKEN),
                         KeywordAction.NONE));
+
+        //--------------------------------MOCK
         keywordInfo.put(Constants.MOCK_KEYWORD,
                 new Keyword(Constants.MOCK_KEYWORD,
                         Arrays.asList(Constants.MOCK_TYPE),
                         KeywordAction.NONE));
+
+        //--------------------------------END MOCK
         keywordInfo.put(Constants.ENDMOCK_KEYWORD,
                 new Keyword(Constants.ENDMOCK_KEYWORD,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -260,12 +317,14 @@ public class Keywords {
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
 
+        //--------------------------------MOCK TYPE
         keywordInfo.put(Constants.MOCK_TYPE,
                 new Keyword(Constants.MOCK_TYPE,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD),
                         KeywordAction.NONE));
 
+        //--------------------------------USING
         keywordInfo.put(Constants.USING_TOKEN,
                 new Keyword(Constants.USING_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -273,22 +332,32 @@ public class Keywords {
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN),
                         KeywordAction.NONE));
+
+        //--------------------------------BY REFERENCE
         keywordInfo.put(Constants.BY_REFERENCE_TOKEN,
                 new Keyword(Constants.BY_REFERENCE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------BY CONTENT
         keywordInfo.put(Constants.BY_CONTENT_TOKEN,
                 new Keyword(Constants.BY_CONTENT_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------BY VALUE
         keywordInfo.put(Constants.BY_VALUE_TOKEN,
                 new Keyword(Constants.BY_VALUE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------VERIFY
         keywordInfo.put(Constants.VERIFY_KEYWORD,
                 new Keyword(Constants.VERIFY_KEYWORD,
                         Arrays.asList(Constants.MOCK_TYPE),
                         KeywordAction.NONE));
+
+        //--------------------------------NEVER HAPPENED
         keywordInfo.put(Constants.NEVER_HAPPENED_KEYWORD,
                 new Keyword(Constants.NEVER_HAPPENED_KEYWORD,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -298,11 +367,15 @@ public class Keywords {
                                 Constants.VERIFY_KEYWORD,
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------HAPPENED
         keywordInfo.put(Constants.HAPPENED_KEYWORD,
                 new Keyword(Constants.HAPPENED_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.AT_LEAST_KEYWORD,
                                 Constants.NO_MORE_THAN_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------ONCE
         keywordInfo.put(Constants.ONCE_KEYWORD,
                 new Keyword(Constants.ONCE_KEYWORD,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -312,14 +385,20 @@ public class Keywords {
                                 Constants.VERIFY_KEYWORD,
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------AT LEAST
         keywordInfo.put(Constants.AT_LEAST_KEYWORD,
                 new Keyword(Constants.AT_LEAST_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------NO MORE THAN
         keywordInfo.put(Constants.NO_MORE_THAN_KEYWORD,
                 new Keyword(Constants.NO_MORE_THAN_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------TIME
         keywordInfo.put(Constants.TIME_KEYWORD,
                 new Keyword(Constants.TIME_KEYWORD,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -329,6 +408,8 @@ public class Keywords {
                                 Constants.VERIFY_KEYWORD,
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
+
+        //--------------------------------TIMES
         keywordInfo.put(Constants.TIMES_KEYWORD,
                 new Keyword(Constants.TIMES_KEYWORD,
                         Arrays.asList(Constants.COBOL_TOKEN,
@@ -339,7 +420,6 @@ public class Keywords {
                                 Constants.EXPECT_KEYWORD),
                         KeywordAction.NONE));
 
-        //TODO: Add other types that can be mocked
         mockTypes = Arrays.asList(Constants.SECTION_TOKEN, Constants.PARAGRAPH_TOKEN, Constants.PARA_TOKEN, Constants.CALL_TOKEN);
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -33,7 +33,7 @@ public class Keywords {
         //--------------------------------EXPECT
         keywordInfo.put(Constants.EXPECT_KEYWORD,
                 new Keyword(Constants.EXPECT_KEYWORD,
-                        Arrays.asList(),
+                        Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
@@ -88,7 +88,9 @@ public class Keywords {
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.IN_KEYWORD,
-                                    Constants.OF_KEYWORD)
+                                    Constants.OF_KEYWORD,
+                                    Constants.PARENTHESIS_ENCLOSED_KEYWORD,
+                                    Constants.HAPPENED_KEYWORD)
                             );
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.HAPPENED_KEYWORD,
@@ -277,6 +279,12 @@ public class Keywords {
                                 Constants.MOCK_KEYWORD,
                                 Constants.VERIFY_KEYWORD,
                                 Constants.EXPECT_KEYWORD),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.TO_BE_KEYWORD
+                                    )
+                            );
+                        }},
                         KeywordAction.COBOL_STATEMENT));
 
         //--------------------------------ALPHANUMERIC LITERAL
@@ -295,6 +303,7 @@ public class Keywords {
                                 Constants.AFTER_EACH_TOKEN_HYPHEN,
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
+                                Constants.ENDMOCK_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
@@ -329,7 +338,8 @@ public class Keywords {
                                 Constants.TIMES_KEYWORD),
                     new HashMap<String, List<String>>() {{
                         put(Constants.VERIFY_KEYWORD, Arrays.asList(
-                                Constants.TIMES_KEYWORD)
+                                Constants.TIMES_KEYWORD,
+                                Constants.TIME_KEYWORD)
                             );
                         }},
                         KeywordAction.FIELDNAME));
@@ -356,7 +366,9 @@ public class Keywords {
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.TIME_KEYWORD,
-                                Constants.TIMES_KEYWORD),
+                                Constants.TIMES_KEYWORD,
+                                Constants.IN_KEYWORD,
+                                Constants.OF_KEYWORD),
                         KeywordAction.COBOL_STATEMENT));
 
         //--------------------------------BOOLEAN VALUE
@@ -406,7 +418,8 @@ public class Keywords {
         //--------------------------------IN
         keywordInfo.put(Constants.IN_KEYWORD,
                 new Keyword(Constants.IN_KEYWORD,
-                        Arrays.asList(),
+                        Arrays.asList(Constants.COBOL_TOKEN,
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
@@ -417,7 +430,7 @@ public class Keywords {
         //--------------------------------OF
         keywordInfo.put(Constants.OF_KEYWORD,
                 new Keyword(Constants.OF_KEYWORD,
-                        Arrays.asList(),
+                        Arrays.asList(Constants.COBOL_TOKEN),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
@@ -569,7 +582,9 @@ public class Keywords {
                                     Constants.ZERO_TOKEN,
                                     Constants.AT_LEAST_KEYWORD,
                                     Constants.NO_MORE_THAN_KEYWORD
-                                    )
+                                    ));
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ONCE_KEYWORD)
                             );
                         }},
                         KeywordAction.NONE));
@@ -591,7 +606,8 @@ public class Keywords {
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
                         new HashMap<String, List<String>>() {{
                               put(Constants.VERIFY_KEYWORD, Arrays.asList(
-                                    Constants.NUMERIC_LITERAL_KEYWORD)
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                      Constants.ONCE_KEYWORD)
                             );
                         }},
                         KeywordAction.NONE));
@@ -602,7 +618,8 @@ public class Keywords {
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
-                                    Constants.NUMERIC_LITERAL_KEYWORD)
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.ONCE_KEYWORD)
                             );
                         }},
                         KeywordAction.NONE));

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -83,7 +83,15 @@ public class Keywords {
                                     Constants.EQUAL_SIGN_KEYWORD,
                                     Constants.GREATER_THAN_SIGN_KEYWORD,
                                     Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
-                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD)
+                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.IN_KEYWORD,
+                                    Constants.OF_KEYWORD)
+                            );
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.HAPPENED_KEYWORD,
+                                    Constants.USING_TOKEN,
+                                    Constants.NEVER_HAPPENED_KEYWORD)
                             );
                         }},
                         KeywordAction.FIELDNAME));
@@ -99,6 +107,18 @@ public class Keywords {
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.TO_BE_KEYWORD,
+                                    Constants.TO_EQUAL_KEYWORD,
+                                    Constants.EQUAL_SIGN_KEYWORD,
+                                    Constants.NOT_EQUAL_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD)
+                            );
+                        }},
                         KeywordAction.REVERSE_LOGIC));
 
         //--------------------------------NOT EQUAL SIGN
@@ -109,6 +129,12 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD)
+                            );
+                        }},
                         KeywordAction.REVERSE_LOGIC));
 
         //--------------------------------TO BE
@@ -279,7 +305,12 @@ public class Keywords {
                                     Constants.BY_REFERENCE_TOKEN,
                                     Constants.BY_CONTENT_TOKEN,
                                     Constants.BY_VALUE_TOKEN,
-                                    Constants.USING_TOKEN));
+                                    Constants.USING_TOKEN)
+                            );
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.HAPPENED_KEYWORD,
+                                    Constants.USING_TOKEN)
+                            );
                             }},
                         KeywordAction.FIELDNAME));
 
@@ -294,6 +325,11 @@ public class Keywords {
                                 Constants.VERIFY_KEYWORD,
                                 Constants.TIME_KEYWORD,
                                 Constants.TIMES_KEYWORD),
+                    new HashMap<String, List<String>>() {{
+                        put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                Constants.TIMES_KEYWORD)
+                            );
+                        }},
                         KeywordAction.FIELDNAME));
 
         //--------------------------------COBOL TOKEN
@@ -365,6 +401,29 @@ public class Keywords {
                                 Constants.MOCK_KEYWORD),
                         KeywordAction.NONE));
 
+        //--------------------------------IN
+        keywordInfo.put(Constants.IN_KEYWORD,
+                new Keyword(Constants.IN_KEYWORD,
+                        Arrays.asList(),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
+                        KeywordAction.NONE));
+
+        //--------------------------------OF
+        keywordInfo.put(Constants.OF_KEYWORD,
+                new Keyword(Constants.OF_KEYWORD,
+                        Arrays.asList(),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
+                        KeywordAction.NONE));
+
+
         //TODO: Remove hyphen keyword option? Backwards compatibility
         //--------------------------------BEFORE-EACH
         keywordInfo.put(Constants.BEFORE_EACH_TOKEN_HYPHEN,
@@ -415,10 +474,8 @@ public class Keywords {
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD));
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
-                                    Constants.HAPPENED_KEYWORD,
-                                    Constants.USING_TOKEN,
-                                    Constants.NEVER_HAPPENED_KEYWORD,
-                                    Constants.NEVER_HAPPENED_KEYWORD)
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD)
                                     );
                         }},
                         KeywordAction.NONE));
@@ -480,8 +537,13 @@ public class Keywords {
         //--------------------------------VERIFY
         keywordInfo.put(Constants.VERIFY_KEYWORD,
                 new Keyword(Constants.VERIFY_KEYWORD,
-                        Arrays.asList(Constants.MOCK_TYPE),
-                        KeywordAction.NONE));
+                        Arrays.asList(),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.MOCK_TYPE)
+                            );
+                        }},
+                        KeywordAction.ACTUAL_FIELDNAME));
 
         //--------------------------------NEVER HAPPENED
         keywordInfo.put(Constants.NEVER_HAPPENED_KEYWORD,
@@ -499,6 +561,16 @@ public class Keywords {
                 new Keyword(Constants.HAPPENED_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.AT_LEAST_KEYWORD,
                                 Constants.NO_MORE_THAN_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.ONCE_KEYWORD,
+                                    Constants.ZERO_TOKEN,
+                                    Constants.AT_LEAST_KEYWORD,
+                                    Constants.NO_MORE_THAN_KEYWORD
+                                    )
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------ONCE
@@ -516,12 +588,22 @@ public class Keywords {
         keywordInfo.put(Constants.AT_LEAST_KEYWORD,
                 new Keyword(Constants.AT_LEAST_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        new HashMap<String, List<String>>() {{
+                              put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.NUMERIC_LITERAL_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------NO MORE THAN
         keywordInfo.put(Constants.NO_MORE_THAN_KEYWORD,
                 new Keyword(Constants.NO_MORE_THAN_KEYWORD,
                         Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.NUMERIC_LITERAL_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------TIME

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -89,12 +89,15 @@ public class Keywords {
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.IN_KEYWORD,
                                     Constants.OF_KEYWORD,
-                                    Constants.PARENTHESIS_ENCLOSED_KEYWORD,
-                                    Constants.HAPPENED_KEYWORD)
+                                    Constants.PARENTHESIS_ENCLOSED_KEYWORD)
                             );
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
-                                    Constants.HAPPENED_KEYWORD,
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.BY_REFERENCE_TOKEN,
+                                    Constants.BY_CONTENT_TOKEN,
+                                    Constants.BY_VALUE_TOKEN,
                                     Constants.USING_TOKEN,
+                                    Constants.HAPPENED_KEYWORD,
                                     Constants.NEVER_HAPPENED_KEYWORD)
                             );
                         }},
@@ -523,6 +526,9 @@ public class Keywords {
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
                             );
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
                         }},
                         KeywordAction.NONE));
 
@@ -534,6 +540,9 @@ public class Keywords {
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
                             );
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
                         }},
                         KeywordAction.NONE));
 
@@ -543,6 +552,9 @@ public class Keywords {
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
                             );
                         }},
@@ -583,9 +595,6 @@ public class Keywords {
                                     Constants.AT_LEAST_KEYWORD,
                                     Constants.NO_MORE_THAN_KEYWORD
                                     ));
-                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
-                                    Constants.ONCE_KEYWORD)
-                            );
                         }},
                         KeywordAction.NONE));
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -15,6 +15,7 @@ import java.util.*;
 public class Keywords {
     private static final Map<String, Keyword> keywordInfo;
     private static final List<String> mockTypes;
+    private static final List<String> qualifiedNameKeywords;
 
     static {
         keywordInfo = new HashMap<>();
@@ -44,17 +45,12 @@ public class Keywords {
         //--------------------------------FIELD NAME
         keywordInfo.put(Constants.FIELDNAME_KEYWORD,
                 new Keyword(Constants.FIELDNAME_KEYWORD,
-                        Arrays.asList(Constants.TO_BE_KEYWORD,
-                                Constants.NOT_KEYWORD,
-                                Constants.NOT_EQUAL_SIGN_KEYWORD,
-                                Constants.TO_EQUAL_KEYWORD,
+                        Arrays.asList(Constants.NOT_KEYWORD,
                                 Constants.EQUAL_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
-                                Constants.HAPPENED_KEYWORD,
-                                Constants.NEVER_HAPPENED_KEYWORD,
                                 Constants.COBOL_TOKEN,
                                 Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
@@ -62,8 +58,7 @@ public class Keywords {
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
                                 Constants.USING_TOKEN,
-                                Constants.IN_KEYWORD,
-                                Constants.OF_KEYWORD),
+                                Constants.QUALIFIED_FIELD_NAME),
                         new HashMap<String, List<String>>() {{
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.ENDMOCK_KEYWORD,
@@ -87,8 +82,7 @@ public class Keywords {
                                     Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                     Constants.FIELDNAME_KEYWORD,
-                                    Constants.IN_KEYWORD,
-                                    Constants.OF_KEYWORD,
+                                    Constants.QUALIFIED_FIELD_NAME,
                                     Constants.PARENTHESIS_ENCLOSED_KEYWORD)
                             );
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
@@ -106,10 +100,7 @@ public class Keywords {
         //--------------------------------NOT
         keywordInfo.put(Constants.NOT_KEYWORD,
                 new Keyword(Constants.NOT_KEYWORD,
-                        Arrays.asList(Constants.TO_BE_KEYWORD,
-                                Constants.TO_EQUAL_KEYWORD,
-                                Constants.EQUAL_SIGN_KEYWORD,
-                                Constants.NOT_EQUAL_SIGN_KEYWORD,
+                        Arrays.asList(Constants.EQUAL_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
@@ -131,11 +122,7 @@ public class Keywords {
         //--------------------------------NOT EQUAL SIGN
         keywordInfo.put(Constants.NOT_EQUAL_SIGN_KEYWORD,
                 new Keyword(Constants.NOT_EQUAL_SIGN_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD,
-                                Constants.COBOL_TOKEN,
-                                Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                                Constants.NUMERIC_LITERAL_KEYWORD,
-                                Constants.BOOLEAN_VALUE),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
@@ -147,11 +134,7 @@ public class Keywords {
         //--------------------------------TO BE
         keywordInfo.put(Constants.TO_BE_KEYWORD,
                 new Keyword(Constants.TO_BE_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD,
-                                Constants.COBOL_TOKEN,
-                                Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                                Constants.NUMERIC_LITERAL_KEYWORD,
-                                Constants.BOOLEAN_VALUE),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
@@ -164,11 +147,7 @@ public class Keywords {
         //--------------------------------TO EQUAL
         keywordInfo.put(Constants.TO_EQUAL_KEYWORD,
                 new Keyword(Constants.TO_EQUAL_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD,
-                                Constants.COBOL_TOKEN,
-                                Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                                Constants.NUMERIC_LITERAL_KEYWORD,
-                                Constants.BOOLEAN_VALUE),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
@@ -267,11 +246,8 @@ public class Keywords {
         keywordInfo.put(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                 new Keyword(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                         Arrays.asList(Constants.PARENTHESIS_ENCLOSED_KEYWORD,
-                                Constants.TO_BE_KEYWORD,
-                                Constants.TO_EQUAL_KEYWORD,
                                 Constants.NOT_KEYWORD,
                                 Constants.EQUAL_SIGN_KEYWORD,
-                                Constants.NOT_EQUAL_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
@@ -284,8 +260,21 @@ public class Keywords {
                                 Constants.EXPECT_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
-                                    Constants.TO_BE_KEYWORD
-                                    )
+                                    Constants.TO_BE_KEYWORD,
+                                    Constants.EQUAL_SIGN_KEYWORD,
+                                    Constants.TO_EQUAL_KEYWORD,
+                                    Constants.NOT_KEYWORD,
+                                    Constants.LESS_THAN_SIGN_KEYWORD,
+                                    Constants.NOT_EQUAL_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_SIGN_KEYWORD,
+                                    Constants.EQUAL_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.QUALIFIED_FIELD_NAME,
+                                    Constants.PARENTHESIS_ENCLOSED_KEYWORD)
                             );
                         }},
                         KeywordAction.COBOL_STATEMENT));
@@ -304,9 +293,6 @@ public class Keywords {
                                 Constants.BEFORE_EACH_TOKEN_HYPHEN,
                                 Constants.AFTER_EACH_TOKEN,
                                 Constants.AFTER_EACH_TOKEN_HYPHEN,
-                                Constants.HAPPENED_KEYWORD,
-                                Constants.NEVER_HAPPENED_KEYWORD,
-                                Constants.ENDMOCK_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
@@ -322,8 +308,9 @@ public class Keywords {
                                     Constants.USING_TOKEN)
                             );
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.USING_TOKEN,
                                     Constants.HAPPENED_KEYWORD,
-                                    Constants.USING_TOKEN)
+                                    Constants.NEVER_HAPPENED_KEYWORD)
                             );
                             }},
                         KeywordAction.FIELDNAME));
@@ -337,7 +324,6 @@ public class Keywords {
                                 Constants.TESTCASE_KEYWORD,
                                 Constants.MOCK_KEYWORD,
                                 Constants.VERIFY_KEYWORD,
-                                Constants.TIME_KEYWORD,
                                 Constants.TIMES_KEYWORD),
                     new HashMap<String, List<String>>() {{
                         put(Constants.VERIFY_KEYWORD, Arrays.asList(
@@ -359,7 +345,6 @@ public class Keywords {
                                 Constants.TESTSUITE_KEYWORD,
                                 Constants.TESTCASE_KEYWORD,
                                 Constants.MOCK_KEYWORD,
-                                Constants.ENDMOCK_KEYWORD,
                                 Constants.VERIFY_KEYWORD,
                                 Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
@@ -370,8 +355,7 @@ public class Keywords {
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.TIME_KEYWORD,
                                 Constants.TIMES_KEYWORD,
-                                Constants.IN_KEYWORD,
-                                Constants.OF_KEYWORD),
+                                Constants.QUALIFIED_FIELD_NAME),
                         KeywordAction.COBOL_STATEMENT));
 
         //--------------------------------BOOLEAN VALUE
@@ -418,22 +402,10 @@ public class Keywords {
                                 Constants.MOCK_KEYWORD),
                         KeywordAction.NONE));
 
-        //--------------------------------IN
-        keywordInfo.put(Constants.IN_KEYWORD,
-                new Keyword(Constants.IN_KEYWORD,
-                        Arrays.asList(Constants.COBOL_TOKEN,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
-                        new HashMap<String, List<String>>() {{
-                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
-                                    Constants.FIELDNAME_KEYWORD)
-                            );
-                        }},
-                        KeywordAction.NONE));
-
-        //--------------------------------OF
-        keywordInfo.put(Constants.OF_KEYWORD,
-                new Keyword(Constants.OF_KEYWORD,
-                        Arrays.asList(Constants.COBOL_TOKEN),
+        //--------------------------------QUALIFIED FIELD NAME
+        keywordInfo.put(Constants.QUALIFIED_FIELD_NAME,
+                new Keyword(Constants.QUALIFIED_FIELD_NAME,
+                        Arrays.asList(Constants.COBOL_TOKEN, Constants.FIELDNAME_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.EXPECT_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD)
@@ -508,7 +480,8 @@ public class Keywords {
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.BY_REFERENCE_TOKEN,
-                                    Constants.BY_CONTENT_TOKEN));
+                                    Constants.BY_CONTENT_TOKEN,
+                                    Constants.BY_VALUE_TOKEN));
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.BY_REFERENCE_TOKEN,
@@ -585,8 +558,7 @@ public class Keywords {
         //--------------------------------HAPPENED
         keywordInfo.put(Constants.HAPPENED_KEYWORD,
                 new Keyword(Constants.HAPPENED_KEYWORD,
-                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.AT_LEAST_KEYWORD,
-                                Constants.NO_MORE_THAN_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.NUMERIC_LITERAL_KEYWORD,
@@ -612,7 +584,7 @@ public class Keywords {
         //--------------------------------AT LEAST
         keywordInfo.put(Constants.AT_LEAST_KEYWORD,
                 new Keyword(Constants.AT_LEAST_KEYWORD,
-                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                               put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.NUMERIC_LITERAL_KEYWORD,
@@ -624,7 +596,7 @@ public class Keywords {
         //--------------------------------NO MORE THAN
         keywordInfo.put(Constants.NO_MORE_THAN_KEYWORD,
                 new Keyword(Constants.NO_MORE_THAN_KEYWORD,
-                        Arrays.asList(Constants.ONCE_KEYWORD, Constants.NUMERIC_LITERAL_KEYWORD),
+                        Arrays.asList(),
                         new HashMap<String, List<String>>() {{
                             put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.NUMERIC_LITERAL_KEYWORD,
@@ -656,6 +628,7 @@ public class Keywords {
                         KeywordAction.NONE));
 
         mockTypes = Arrays.asList(Constants.SECTION_TOKEN, Constants.PARAGRAPH_TOKEN, Constants.PARA_TOKEN, Constants.CALL_TOKEN);
+        qualifiedNameKeywords = Arrays.asList(Constants.IN_KEYWORD, Constants.OF_KEYWORD);
     }
 
 
@@ -691,6 +664,9 @@ public class Keywords {
                 }
                 if (mockTypes.contains(key)) {
                     key = Constants.MOCK_TYPE;
+                }
+                if (qualifiedNameKeywords.contains(key)){
+                    key = Constants.QUALIFIED_FIELD_NAME;
                 }
             }
         }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -33,7 +33,12 @@ public class Keywords {
         //--------------------------------EXPECT
         keywordInfo.put(Constants.EXPECT_KEYWORD,
                 new Keyword(Constants.EXPECT_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD),
+                        Arrays.asList(),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
                         KeywordAction.ACTUAL_FIELDNAME));
 
         //--------------------------------FIELD NAME
@@ -66,6 +71,20 @@ public class Keywords {
                                     Constants.BY_CONTENT_TOKEN,
                                     Constants.BY_VALUE_TOKEN,
                                     Constants.USING_TOKEN)
+                            );
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.TO_BE_KEYWORD,
+                                    Constants.EQUAL_SIGN_KEYWORD,
+                                    Constants.TO_EQUAL_KEYWORD,
+                                    Constants.NOT_KEYWORD,
+                                    Constants.LESS_THAN_SIGN_KEYWORD,
+                                    Constants.NOT_EQUAL_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_SIGN_KEYWORD,
+                                    Constants.EQUAL_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_SIGN_KEYWORD,
+                                    Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
+                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD
+                                    )
                             );
                         }},
                         KeywordAction.FIELDNAME));

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -5,8 +5,6 @@ import org.openmainframeproject.cobolcheck.services.log.Log;
 
 import java.util.*;
 
-import static java.util.Map.entry;
-
 /**
  * This is a container for Keyword records. It is used when parsing test suites to identify cobol-check
  * keywords and handle them appropriately.
@@ -24,19 +22,19 @@ public class Keywords {
         keywordInfo.put(Constants.TESTSUITE_KEYWORD,
                 new Keyword(Constants.TESTSUITE_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD),
-                    KeywordAction.TESTSUITE_NAME));
+                        KeywordAction.TESTSUITE_NAME));
 
         //--------------------------------TESTCASE
         keywordInfo.put(Constants.TESTCASE_KEYWORD,
                 new Keyword(Constants.TESTCASE_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD),
-                    KeywordAction.NEW_TESTCASE));
+                        KeywordAction.NEW_TESTCASE));
 
         //--------------------------------EXPECT
         keywordInfo.put(Constants.EXPECT_KEYWORD,
                 new Keyword(Constants.EXPECT_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
-                    KeywordAction.ACTUAL_FIELDNAME));
+                        KeywordAction.ACTUAL_FIELDNAME));
 
         //--------------------------------FIELD NAME
         keywordInfo.put(Constants.FIELDNAME_KEYWORD,
@@ -60,16 +58,16 @@ public class Keywords {
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
                                 Constants.USING_TOKEN),
-                                Map.ofEntries(
-                                        entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                                Constants.ENDMOCK_KEYWORD,
-                                                Constants.FIELDNAME_KEYWORD,
-                                                Constants.BY_REFERENCE_TOKEN,
-                                                Constants.BY_CONTENT_TOKEN,
-                                                Constants.BY_VALUE_TOKEN,
-                                                Constants.USING_TOKEN
-                                                ))
-                                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.ENDMOCK_KEYWORD,
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.BY_REFERENCE_TOKEN,
+                                    Constants.BY_CONTENT_TOKEN,
+                                    Constants.BY_VALUE_TOKEN,
+                                    Constants.USING_TOKEN)
+                            );
+                        }},
                         KeywordAction.FIELDNAME));
 
         //--------------------------------NOT
@@ -207,16 +205,16 @@ public class Keywords {
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
                                 Constants.USING_TOKEN),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.ENDMOCK_KEYWORD,
-                                        Constants.FIELDNAME_KEYWORD,
-                                        Constants.BY_REFERENCE_TOKEN,
-                                        Constants.BY_CONTENT_TOKEN,
-                                        Constants.BY_VALUE_TOKEN,
-                                        Constants.USING_TOKEN
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.ENDMOCK_KEYWORD,
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.BY_REFERENCE_TOKEN,
+                                    Constants.BY_CONTENT_TOKEN,
+                                    Constants.BY_VALUE_TOKEN,
+                                    Constants.USING_TOKEN)
+                            );
+                        }},
                         KeywordAction.FIELDNAME));
 
         //--------------------------------NUMERIC LITERAL
@@ -318,11 +316,12 @@ public class Keywords {
         keywordInfo.put(Constants.MOCK_KEYWORD,
                 new Keyword(Constants.MOCK_KEYWORD,
                         new ArrayList<>(),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.MOCK_TYPE
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                            Constants.MOCK_TYPE
+                                    )
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------END MOCK
@@ -345,12 +344,12 @@ public class Keywords {
                 new Keyword(Constants.MOCK_TYPE,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.FIELDNAME_KEYWORD,
-                                        Constants.ALPHANUMERIC_LITERAL_KEYWORD
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------USING
@@ -360,47 +359,47 @@ public class Keywords {
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.FIELDNAME_KEYWORD,
-                                        Constants.BY_REFERENCE_TOKEN,
-                                        Constants.BY_CONTENT_TOKEN,
-                                        Constants.BY_VALUE_TOKEN
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.BY_REFERENCE_TOKEN,
+                                    Constants.BY_CONTENT_TOKEN,
+                                    Constants.BY_VALUE_TOKEN)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------BY REFERENCE
         keywordInfo.put(Constants.BY_REFERENCE_TOKEN,
                 new Keyword(Constants.BY_REFERENCE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.FIELDNAME_KEYWORD
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------BY CONTENT
         keywordInfo.put(Constants.BY_CONTENT_TOKEN,
                 new Keyword(Constants.BY_CONTENT_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.FIELDNAME_KEYWORD
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------BY VALUE
         keywordInfo.put(Constants.BY_VALUE_TOKEN,
                 new Keyword(Constants.BY_VALUE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
-                        Map.ofEntries(
-                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
-                                        Constants.FIELDNAME_KEYWORD
-                                ))
-                        ),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD)
+                            );
+                        }},
                         KeywordAction.NONE));
 
         //--------------------------------VERIFY
@@ -476,15 +475,14 @@ public class Keywords {
     }
 
 
-
     public static Keyword getKeywordFor(String key, boolean expectFieldName) {
         Keyword result = null;
-        if (key != null && ! key.isEmpty()) {
+        if (key != null && !key.isEmpty()) {
             Log.debug("Key: " + key);
             if (key.startsWith("\"") || key.startsWith("'")) {
                 key = Constants.ALPHANUMERIC_LITERAL_KEYWORD;
             }
-            if (key.startsWith("(")){
+            if (key.startsWith("(")) {
                 key = Constants.PARENTHESIS_ENCLOSED_KEYWORD;
             } else {
                 if (Character.isDigit(key.charAt(0))) {
@@ -500,13 +498,14 @@ public class Keywords {
                     if (isNumeric) {
                         key = Constants.NUMERIC_LITERAL_KEYWORD;
                     }
-                } else if (key.equals(Constants.ZERO_TOKEN)){
+                } else if (key.equals(Constants.ZERO_TOKEN)) {
                     key = Constants.NUMERIC_LITERAL_KEYWORD;
-                }else {
+                } else {
                     if (key.equals("TRUE") || key.equals("FALSE")) {
                         key = Constants.BOOLEAN_VALUE;
                     }
-                } if (mockTypes.contains(key)){
+                }
+                if (mockTypes.contains(key)) {
                     key = Constants.MOCK_TYPE;
                 }
             }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -56,13 +56,14 @@ public class Keywords {
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
                                 Constants.COBOL_TOKEN,
-                                Constants.FIELDNAME_KEYWORD,
                                 Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
-                                Constants.USING_TOKEN),
+                                Constants.USING_TOKEN,
+                                Constants.IN_KEYWORD,
+                                Constants.OF_KEYWORD),
                         new HashMap<String, List<String>>() {{
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.ENDMOCK_KEYWORD,
@@ -85,6 +86,7 @@ public class Keywords {
                                     Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                     Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                     Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.FIELDNAME_KEYWORD,
                                     Constants.IN_KEYWORD,
                                     Constants.OF_KEYWORD)
                             );
@@ -422,7 +424,6 @@ public class Keywords {
                             );
                         }},
                         KeywordAction.NONE));
-
 
         //TODO: Remove hyphen keyword option? Backwards compatibility
         //--------------------------------BEFORE-EACH

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -83,8 +83,7 @@ public class Keywords {
                                     Constants.EQUAL_SIGN_KEYWORD,
                                     Constants.GREATER_THAN_SIGN_KEYWORD,
                                     Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
-                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD
-                                    )
+                                    Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD)
                             );
                         }},
                         KeywordAction.FIELDNAME));
@@ -120,6 +119,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------TO EQUAL
@@ -130,6 +136,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------EQUAL SIGN
@@ -140,6 +153,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------GREATER THAN SIGN
@@ -150,6 +170,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------GREATER THAN EQUAL TO SIGN
@@ -160,6 +187,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------LESS THAN SIGN
@@ -170,6 +204,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------LESS THAN EQUAL TO SIGN
@@ -180,6 +221,13 @@ public class Keywords {
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD,
                                 Constants.NUMERIC_LITERAL_KEYWORD,
                                 Constants.BOOLEAN_VALUE),
+                        new HashMap<String, List<String>>() {{
+                            put(Constants.EXPECT_KEYWORD, Arrays.asList(
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                                    Constants.NUMERIC_LITERAL_KEYWORD,
+                                    Constants.BOOLEAN_VALUE)
+                            );
+                        }},
                         KeywordAction.EXPECTED_VALUE));
 
         //--------------------------------PARENTHESIS-ENCLOSED
@@ -231,9 +279,8 @@ public class Keywords {
                                     Constants.BY_REFERENCE_TOKEN,
                                     Constants.BY_CONTENT_TOKEN,
                                     Constants.BY_VALUE_TOKEN,
-                                    Constants.USING_TOKEN)
-                            );
-                        }},
+                                    Constants.USING_TOKEN));
+                            }},
                         KeywordAction.FIELDNAME));
 
         //--------------------------------NUMERIC LITERAL
@@ -366,8 +413,13 @@ public class Keywords {
                         new HashMap<String, List<String>>() {{
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD,
-                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD)
-                            );
+                                    Constants.ALPHANUMERIC_LITERAL_KEYWORD));
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
+                                    Constants.HAPPENED_KEYWORD,
+                                    Constants.USING_TOKEN,
+                                    Constants.NEVER_HAPPENED_KEYWORD,
+                                    Constants.NEVER_HAPPENED_KEYWORD)
+                                    );
                         }},
                         KeywordAction.NONE));
 
@@ -380,6 +432,10 @@ public class Keywords {
                                 Constants.BY_VALUE_TOKEN),
                         new HashMap<String, List<String>>() {{
                             put(Constants.MOCK_KEYWORD, Arrays.asList(
+                                    Constants.FIELDNAME_KEYWORD,
+                                    Constants.BY_REFERENCE_TOKEN,
+                                    Constants.BY_CONTENT_TOKEN));
+                            put(Constants.VERIFY_KEYWORD, Arrays.asList(
                                     Constants.FIELDNAME_KEYWORD,
                                     Constants.BY_REFERENCE_TOKEN,
                                     Constants.BY_CONTENT_TOKEN,

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Keywords.java
@@ -54,7 +54,12 @@ public class Keywords {
                                 Constants.NEVER_HAPPENED_KEYWORD,
                                 Constants.COBOL_TOKEN,
                                 Constants.FIELDNAME_KEYWORD,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD),
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
+                                Constants.FIELDNAME_KEYWORD,
+                                Constants.BY_REFERENCE_TOKEN,
+                                Constants.BY_CONTENT_TOKEN,
+                                Constants.BY_VALUE_TOKEN,
+                                Constants.USING_TOKEN),
                                 Map.ofEntries(
                                         entry(Constants.MOCK_KEYWORD, Arrays.asList(
                                                 Constants.ENDMOCK_KEYWORD,
@@ -197,8 +202,21 @@ public class Keywords {
                                 Constants.AFTER_EACH_TOKEN_HYPHEN,
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
-                                Constants.USING_TOKEN,
-                                Constants.ENDMOCK_KEYWORD),
+                                Constants.FIELDNAME_KEYWORD,
+                                Constants.BY_REFERENCE_TOKEN,
+                                Constants.BY_CONTENT_TOKEN,
+                                Constants.BY_VALUE_TOKEN,
+                                Constants.USING_TOKEN),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.ENDMOCK_KEYWORD,
+                                        Constants.FIELDNAME_KEYWORD,
+                                        Constants.BY_REFERENCE_TOKEN,
+                                        Constants.BY_CONTENT_TOKEN,
+                                        Constants.BY_VALUE_TOKEN,
+                                        Constants.USING_TOKEN
+                                ))
+                        ),
                         KeywordAction.FIELDNAME));
 
         //--------------------------------NUMERIC LITERAL
@@ -299,7 +317,12 @@ public class Keywords {
         //--------------------------------MOCK
         keywordInfo.put(Constants.MOCK_KEYWORD,
                 new Keyword(Constants.MOCK_KEYWORD,
-                        Arrays.asList(Constants.MOCK_TYPE),
+                        new ArrayList<>(),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.MOCK_TYPE
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------END MOCK
@@ -322,6 +345,12 @@ public class Keywords {
                 new Keyword(Constants.MOCK_TYPE,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
                                 Constants.ALPHANUMERIC_LITERAL_KEYWORD),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.FIELDNAME_KEYWORD,
+                                        Constants.ALPHANUMERIC_LITERAL_KEYWORD
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------USING
@@ -331,24 +360,47 @@ public class Keywords {
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.FIELDNAME_KEYWORD,
+                                        Constants.BY_REFERENCE_TOKEN,
+                                        Constants.BY_CONTENT_TOKEN,
+                                        Constants.BY_VALUE_TOKEN
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------BY REFERENCE
         keywordInfo.put(Constants.BY_REFERENCE_TOKEN,
                 new Keyword(Constants.BY_REFERENCE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.FIELDNAME_KEYWORD
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------BY CONTENT
         keywordInfo.put(Constants.BY_CONTENT_TOKEN,
                 new Keyword(Constants.BY_CONTENT_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.FIELDNAME_KEYWORD
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------BY VALUE
         keywordInfo.put(Constants.BY_VALUE_TOKEN,
                 new Keyword(Constants.BY_VALUE_TOKEN,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
+                        Map.ofEntries(
+                                entry(Constants.MOCK_KEYWORD, Arrays.asList(
+                                        Constants.FIELDNAME_KEYWORD
+                                ))
+                        ),
                         KeywordAction.NONE));
 
         //--------------------------------VERIFY

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Mock.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/Mock.java
@@ -1,6 +1,7 @@
 package org.openmainframeproject.cobolcheck.features.testSuiteParser;
 
 import org.openmainframeproject.cobolcheck.services.Config;
+import org.openmainframeproject.cobolcheck.services.StringHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -124,11 +125,11 @@ public class Mock {
     }
 
     public void addLine(String line) {
-        lines.add(line);
+        lines.add(StringHelper.moveToAreaB(line));
     }
 
     public void addLines(List<String> lines) {
-        this.lines.addAll(lines);
+        this.lines.addAll(StringHelper.moveToAreaB(lines));
     }
 
     public void addArgument(String argument) {arguments.add(argument);}

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -30,10 +30,11 @@ public class TestSuiteErrorLog {
 
     private boolean errorOccured = false;
 
+    //TODO: Add all words here
     private final List<String> cobolCheckStartingAndEndingKeywords = Arrays.asList(Constants.TESTSUITE_KEYWORD,
             Constants.TESTCASE_KEYWORD, Constants.EXPECT_KEYWORD, Constants.MOCK_KEYWORD, Constants.ENDMOCK_KEYWORD,
             Constants.VERIFY_KEYWORD, Constants.BEFORE_EACH_TOKEN, Constants.END_BEFORE_TOKEN, Constants.AFTER_EACH_TOKEN,
-            Constants.END_AFTER_TOKEN);
+            Constants.END_AFTER_TOKEN, Constants.HAPPENED_KEYWORD);
 
     private String errorLogPath;
 
@@ -52,10 +53,9 @@ public class TestSuiteErrorLog {
 
     public String getLastKeywordValue() { return lastKeyword.value(); }
 
-    public void checkExpectedTokenSyntax(Keyword currentKeyword, String currentToken, String currentFile, int lineNumber, int lineIndex){
-        ContextHandler.tryEnterContext(currentToken);
+    public boolean checkExpectedTokenSyntax(Keyword currentKeyword, String currentToken, String currentFile, int lineNumber, int lineIndex){
+        String error = "";
         if (lastKeyword != null){
-            String error = "";
             if (!lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).contains(currentKeyword.value())){
                 errorOccured = true;
                 String expectedKeywords = Arrays.toString(lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).toArray());
@@ -68,8 +68,11 @@ public class TestSuiteErrorLog {
                 outputError(error);
             }
         }
+        ContextHandler.tryEnterContext(currentToken);
+        ContextHandler.tryExitingContext(currentToken);
         lastKeyword = currentKeyword;
         lastToken = currentToken;
+        return error.isEmpty();
     }
 
     public void checkSyntaxInsideBlock(String blockKeyword, List<String> cobolLines, TokenExtractor tokenExtractor, String currentFile, int lineNumber) {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -26,6 +26,8 @@ public class TestSuiteErrorLog {
 
     private String followingExpectedGotMessage = "Following <%1s> classified as <%2s>" + Constants.NEWLINE +
             "Expected classification: %3s" + Constants.NEWLINE + "Got <%4s> classified as <%5s>";
+    private String followingExpectedInContextGotMessage = "Following <%1s> classified as <%2s>" + Constants.NEWLINE +
+            "Expected classification in the context of %3s: %4s" + Constants.NEWLINE + "Got <%5s> classified as <%6s>";
     private String keywordInBlock = "Cannot have Cobol Check keyword <%1s> inside a %2s block";
 
     private boolean errorOccured = false;
@@ -38,7 +40,7 @@ public class TestSuiteErrorLog {
 
     private String errorLogPath;
 
-    private String lastErrorLogMessage;
+    private String errorLogMessages = "";
 
     public TestSuiteErrorLog(){
         errorLogPath = getTestSuiteParserErrorLogPath();
@@ -49,7 +51,7 @@ public class TestSuiteErrorLog {
         return errorOccured;
     }
 
-    public String getLastErrorMessage(){ return lastErrorLogMessage; }
+    public String getErrorMessages(){ return errorLogMessages; }
 
     public String getLastKeywordValue() { return lastKeyword.value(); }
 
@@ -59,12 +61,18 @@ public class TestSuiteErrorLog {
             if (!lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).contains(currentKeyword.value())){
                 errorOccured = true;
                 String expectedKeywords = Arrays.toString(lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).toArray());
-                String inContext = ContextHandler.insideOfContext() ? " in the context of " + ContextHandler.getCurrentContext() : "";
                 error += String.format(fileMessage, displayErrorType(ErrorTypes.SYNTAX_ERROR), currentFile) + ":" + lineNumber + ":" + lineIndex + ":" + Constants.NEWLINE;
                 error += String.format(lineIndexMessage, lineNumber, lineIndex) + Constants.NEWLINE;
-                error += String.format(followingExpectedGotMessage, lastToken, lastKeyword.value() + inContext, expectedKeywords,
-                        currentToken, currentKeyword.value()) +
-                        Constants.NEWLINE + Constants.NEWLINE;
+                if (ContextHandler.insideOfContext()){
+                    error += String.format(followingExpectedInContextGotMessage, lastToken, lastKeyword.value(), ContextHandler.getCurrentContext() , expectedKeywords,
+                            currentToken, currentKeyword.value()) +
+                            Constants.NEWLINE + Constants.NEWLINE;
+                }
+                else {
+                    error += String.format(followingExpectedGotMessage, lastToken, lastKeyword.value(), expectedKeywords,
+                            currentToken, currentKeyword.value()) +
+                            Constants.NEWLINE + Constants.NEWLINE;
+                }
                 outputError(error);
             }
         }
@@ -139,7 +147,7 @@ public class TestSuiteErrorLog {
     }
 
     private void outputError(String error) {
-        lastErrorLogMessage = error;
+        errorLogMessages += error;
         System.out.println(error);
         BufferedWriter errorLogWriter = null;
         try {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -78,8 +78,8 @@ public class TestSuiteErrorLog {
                 outputError(error);
             }
         }
-        ContextHandler.tryEnterContext(currentToken);
-        ContextHandler.tryExitingContext(currentToken);
+        ContextHandler.tryEnterContext(currentKeyword.value());
+        ContextHandler.tryExitingContext(currentKeyword.value());
         lastKeyword = currentKeyword;
         lastToken = currentToken;
         return error.isEmpty();

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -60,9 +60,9 @@ public class TestSuiteErrorLog {
     public boolean checkExpectedTokenSyntax(Keyword currentKeyword, String currentToken, String currentFile, int lineNumber, int lineIndex){
         String error = "";
         if (lastKeyword != null){
-            if (!lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).contains(currentKeyword.value())){
+            if (!lastKeyword.getValidNextKeys(ContextHandler.getCurrentContext()).contains(currentKeyword.value())){
                 errorOccured = true;
-                String expectedKeywords = Arrays.toString(lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).toArray());
+                String expectedKeywords = Arrays.toString(lastKeyword.getValidNextKeys(ContextHandler.getCurrentContext()).toArray());
                 error += String.format(fileMessage, displayErrorType(ErrorTypes.SYNTAX_ERROR), currentFile) + ":" + lineNumber + ":" + lineIndex + ":" + Constants.NEWLINE;
                 error += String.format(lineIndexMessage, lineNumber, lineIndex) + Constants.NEWLINE;
                 if (ContextHandler.insideOfContext()){

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -53,14 +53,16 @@ public class TestSuiteErrorLog {
     public String getLastKeywordValue() { return lastKeyword.value(); }
 
     public void checkExpectedTokenSyntax(Keyword currentKeyword, String currentToken, String currentFile, int lineNumber, int lineIndex){
+        ContextHandler.tryEnterContext(currentToken);
         if (lastKeyword != null){
             String error = "";
-            if (!lastKeyword.getvalidNextKeys().contains(currentKeyword.value())){
+            if (!lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).contains(currentKeyword.value())){
                 errorOccured = true;
-                String expectedKeywords = Arrays.toString(lastKeyword.getvalidNextKeys().toArray());
+                String expectedKeywords = Arrays.toString(lastKeyword.getvalidNextKeys(ContextHandler.getCurrentContext()).toArray());
+                String inContext = ContextHandler.insideOfContext() ? " in the context of " + ContextHandler.getCurrentContext() : "";
                 error += String.format(fileMessage, displayErrorType(ErrorTypes.SYNTAX_ERROR), currentFile) + ":" + lineNumber + ":" + lineIndex + ":" + Constants.NEWLINE;
                 error += String.format(lineIndexMessage, lineNumber, lineIndex) + Constants.NEWLINE;
-                error += String.format(followingExpectedGotMessage, lastToken, lastKeyword.value(), expectedKeywords,
+                error += String.format(followingExpectedGotMessage, lastToken, lastKeyword.value() + inContext, expectedKeywords,
                         currentToken, currentKeyword.value()) +
                         Constants.NEWLINE + Constants.NEWLINE;
                 outputError(error);

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -32,11 +32,13 @@ public class TestSuiteErrorLog {
 
     private boolean errorOccured = false;
 
-    //TODO: Add all words here
     private final List<String> cobolCheckStartingAndEndingKeywords = Arrays.asList(Constants.TESTSUITE_KEYWORD,
             Constants.TESTCASE_KEYWORD, Constants.EXPECT_KEYWORD, Constants.MOCK_KEYWORD, Constants.ENDMOCK_KEYWORD,
-            Constants.VERIFY_KEYWORD, Constants.BEFORE_EACH_TOKEN, Constants.END_BEFORE_TOKEN, Constants.AFTER_EACH_TOKEN,
-            Constants.END_AFTER_TOKEN, Constants.HAPPENED_KEYWORD);
+            Constants.VERIFY_KEYWORD, Constants.BEFORE_EACH_TOKEN, Constants.END_BEFORE_TOKEN,
+            Constants.AFTER_EACH_TOKEN,
+            Constants.END_AFTER_TOKEN, Constants.HAPPENED_KEYWORD, Constants.TO_BE_KEYWORD, Constants.TO_EQUAL_KEYWORD,
+            Constants.BEFORE_EACH_TOKEN_HYPHEN, Constants.AFTER_EACH_TOKEN_HYPHEN, Constants.NEVER_HAPPENED_KEYWORD,
+            Constants.ONCE_KEYWORD, Constants.AT_LEAST_KEYWORD, Constants.NO_MORE_THAN_KEYWORD);
 
     private String errorLogPath;
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -833,6 +833,8 @@ public class TestSuiteParser {
                 currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
         if (currentMock.getType() == Constants.CALL_TOKEN)
             currentMock.addLines(removeToken(mockLines, "END-CALL"));
+        else
+            currentMock.addLines(mockLines);
         try{
             mockRepository.addMock(currentMock);
         } catch (ComponentMockedTwiceInSameScopeException e){

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -324,6 +324,8 @@ public class TestSuiteParser {
                         if (qualifiedNameKeywords.contains(testSuiteToken)) {
                             fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
                             expectQualifiedName = true;
+                        } else {
+                            fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
                         }
                     } else if (expectInProgress) {
                         fieldNameForExpect = testSuiteToken;
@@ -580,6 +582,12 @@ public class TestSuiteParser {
                     expectInProgress = false;
                     toBeInProgress = true;
                     break;
+
+                case Constants.OF_KEYWORD:
+                case Constants.IN_KEYWORD:
+                    fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
+                    break;
+
             }
 
             // take actions that were triggered by the previous token's action, pertaining

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -1108,9 +1108,16 @@ public class TestSuiteParser {
             lines.add(currentTestSuiteLine);
         }
         if(currentTestSuiteLine.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))){
-            lines.set(0, lines.get(0).replaceAll("(?i)"+ Pattern.quote("foo"), ""));
+            String line = lines.get(0);
+            int startIndex = line.toUpperCase(Locale.ROOT).indexOf(endingKeyword);
+            int endIndex = startIndex + endingKeyword.length();
+            lines.set(0, line.substring(0, startIndex));
             if (lines.get(0).trim().isEmpty())
                 lines.remove(0);
+            if (endIndex < line.length())
+                testSuiteTokens = keywordExtractor.extractTokensFrom(line.substring(endIndex));
+            else
+                testSuiteTokens.clear();
             return lines;
         }
         String line;
@@ -1118,7 +1125,15 @@ public class TestSuiteParser {
                 !line.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))){
             lines.add(line);
         }
-        testSuiteTokens.clear();
+        int startIndex = line.toUpperCase(Locale.ROOT).indexOf(endingKeyword);
+        int endIndex = startIndex + endingKeyword.length();
+        String lineToAdd =  line.substring(0, startIndex);
+        if (!lineToAdd.trim().isEmpty())
+            lines.add(lineToAdd);
+        if (endIndex < line.length())
+            testSuiteTokens = keywordExtractor.extractTokensFrom(line.substring(endIndex));
+        else
+            testSuiteTokens.clear();
         return lines;
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -376,7 +376,7 @@ public class TestSuiteParser {
                                 testSuiteErrorLog.checkSyntaxInsideBlock(Constants.MOCK_KEYWORD, mockLines, keywordExtractor,
                                         currentTestSuiteRealFile, fileLineNumber);
                                 Keyword endMockKeyword = Keywords.getKeywordFor(Constants.ENDMOCK_KEYWORD, false);
-                                testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, testSuiteToken, currentTestSuiteRealFile, fileLineNumber,
+                                testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile, fileLineNumber,
                                         currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
                                 currentMock.addLines(mockLines);
                                 try{

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -34,9 +34,6 @@ public class TestSuiteParser {
 
     private TestSuiteErrorLog testSuiteErrorLog;
 
-    // Source tokens used in fully-qualified data item names
-    private final List<String> qualifiedNameKeywords = Arrays.asList("IN", "OF");
-
     private final BeforeAfterRepo beforeAfterRepo;
 
     // Used for mocking
@@ -320,13 +317,6 @@ public class TestSuiteParser {
                     if (expectQualifiedName) {
                         fieldNameForExpect += testSuiteToken;
                         expectQualifiedName = false;
-                    } else if (possibleQualifiedName) {
-                        if (qualifiedNameKeywords.contains(testSuiteToken)) {
-                            fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
-                            expectQualifiedName = true;
-                        } else {
-                            fieldNameForExpect += Constants.SPACE + testSuiteToken;
-                        }
                     } else if (expectInProgress) {
                         fieldNameForExpect = testSuiteToken;
                         possibleQualifiedName = true;
@@ -591,10 +581,12 @@ public class TestSuiteParser {
                     toBeInProgress = true;
                     break;
 
-                case Constants.OF_KEYWORD:
-                case Constants.IN_KEYWORD:
-                    if (cobolTokenIsFieldName)
-                        fieldNameForExpect += Constants.SPACE + testSuiteToken;
+                case Constants.QUALIFIED_FIELD_NAME:
+                    if (cobolTokenIsFieldName){
+                        fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
+                        expectQualifiedName = true;
+                    }
+
                     else
                         appendTokenToCobolStatement(testSuiteToken);
                     break;

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -383,7 +383,9 @@ public class TestSuiteParser {
 
                     if (verifyInProgress) {
                         if (testSuiteToken.equalsIgnoreCase(Constants.ZERO_TOKEN)) {
-                            currentVerify.setExpectedCount("0");
+                            if (currentVerify != null) {
+                                currentVerify.setExpectedCount("0");
+                            }
                         }
                     }
 
@@ -556,18 +558,24 @@ public class TestSuiteParser {
                     break;
 
                 case Constants.ONCE_KEYWORD:
-                    currentVerify.setExpectedCount("1");
-                    handleEndOfVerifyStatement(parsedTestSuiteLines);
+                    if (currentVerify != null){
+                        currentVerify.setExpectedCount("1");
+                        handleEndOfVerifyStatement(parsedTestSuiteLines);
+                    }
                     break;
 
                 case Constants.AT_LEAST_KEYWORD:
-                    // Actual value is set at next token
-                    currentVerify.expectAtLeast("N/A");
+                    if (currentVerify != null) {
+                        // Actual value is set at next token
+                        currentVerify.expectAtLeast("N/A");
+                    }
                     break;
 
                 case Constants.NO_MORE_THAN_KEYWORD:
-                    // Actual value is set at next token
-                    currentVerify.expectNoMoreThan("N/A");
+                    if (currentVerify != null) {
+                        // Actual value is set at next token
+                        currentVerify.expectNoMoreThan("N/A");
+                    }
                     break;
 
                 case Constants.TIME_KEYWORD:

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -325,7 +325,7 @@ public class TestSuiteParser {
                             fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
                             expectQualifiedName = true;
                         } else {
-                            fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
+                            fieldNameForExpect += Constants.SPACE + testSuiteToken;
                         }
                     } else if (expectInProgress) {
                         fieldNameForExpect = testSuiteToken;
@@ -585,7 +585,10 @@ public class TestSuiteParser {
 
                 case Constants.OF_KEYWORD:
                 case Constants.IN_KEYWORD:
-                    fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
+                    if (cobolTokenIsFieldName)
+                        fieldNameForExpect += Constants.SPACE + testSuiteToken;
+                    else
+                        appendTokenToCobolStatement(testSuiteToken);
                     break;
 
             }

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteParser.java
@@ -14,7 +14,8 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 /**
- * Parses the concatenated test suite and writes Cobol test code to the output stream for the generated test program.
+ * Parses the concatenated test suite and writes Cobol test code to the output
+ * stream for the generated test program.
  *
  * @author Dave Nicolette (neopragma)
  * @since 14
@@ -38,7 +39,7 @@ public class TestSuiteParser {
 
     private final BeforeAfterRepo beforeAfterRepo;
 
-    //Used for mocking
+    // Used for mocking
     MockRepository mockRepository;
     private Mock currentMock;
     private String currentMockArgument = "";
@@ -50,14 +51,15 @@ public class TestSuiteParser {
     private VerifyMockCount currentVerify;
     private boolean verifyInProgress;
 
-
-    // Optionally replace identifier prefixes in cobol-check copybook lines and generated source lines,
+    // Optionally replace identifier prefixes in cobol-check copybook lines and
+    // generated source lines,
     // in case of conflict with prefixes used in programs to be tested.
     // This is set in config.properties, cobolcheck.prefix entry.
     private final String testCodePrefix;
 
     // Flags to keep track of context while reading input source files.
-    // We want to make a single pass of all inputs, so we need to know what we are looking for at any given point.
+    // We want to make a single pass of all inputs, so we need to know what we are
+    // looking for at any given point.
     private boolean emptyTestSuite;
     private boolean cobolStatementInProgress;
     private boolean expectInProgress;
@@ -79,26 +81,16 @@ public class TestSuiteParser {
     private int testCaseNumber = 0;
 
     // Lines inserted into the test program
-    private static final String COBOL_PERFORM_INITIALIZE =
-            "           PERFORM %sINITIALIZE";
-    private static final String COBOL_DISPLAY_TESTSUITE =
-            "           DISPLAY \"TESTSUITE:\"";
-    private static final String COBOL_DISPLAY_NAME =
-            "           DISPLAY %s";
-    private static final String COBOL_STORE_TESTCASE_NAME_1 =
-            "           MOVE %s";
-    private static final String COBOL_STORE_TESTCASE_NAME_2 =
-            "               TO %sTEST-CASE-NAME";
-    private static final String COBOL_STORE_TESTSUITE_NAME_1 =
-            "           MOVE %s";
-    private static final String COBOL_STORE_TESTSUITE_NAME_2 =
-            "               TO %sTEST-SUITE-NAME";
-    private static final String COBOL_PERFORM_BEFORE =
-            "           PERFORM %sBEFORE-EACH";
-    private static final String COBOL_PERFORM_INITIALIZE_MOCK_COUNT =
-            "           PERFORM %sINITIALIZE-MOCK-COUNT";
-    private static final String COBOL_INCREMENT_TEST_CASE_COUNT =
-            "           ADD 1 TO %sTEST-CASE-COUNT";
+    private static final String COBOL_PERFORM_INITIALIZE = "           PERFORM %sINITIALIZE";
+    private static final String COBOL_DISPLAY_TESTSUITE = "           DISPLAY \"TESTSUITE:\"";
+    private static final String COBOL_DISPLAY_NAME = "           DISPLAY %s";
+    private static final String COBOL_STORE_TESTCASE_NAME_1 = "           MOVE %s";
+    private static final String COBOL_STORE_TESTCASE_NAME_2 = "               TO %sTEST-CASE-NAME";
+    private static final String COBOL_STORE_TESTSUITE_NAME_1 = "           MOVE %s";
+    private static final String COBOL_STORE_TESTSUITE_NAME_2 = "               TO %sTEST-SUITE-NAME";
+    private static final String COBOL_PERFORM_BEFORE = "           PERFORM %sBEFORE-EACH";
+    private static final String COBOL_PERFORM_INITIALIZE_MOCK_COUNT = "           PERFORM %sINITIALIZE-MOCK-COUNT";
+    private static final String COBOL_INCREMENT_TEST_CASE_COUNT = "           ADD 1 TO %sTEST-CASE-COUNT";
 
     /**
      * Example: This will look like:
@@ -106,13 +98,10 @@ public class TestSuiteParser {
      * or when NOT is specified:
      * SET UT-REVERSE-COMPARE TO TRUE
      */
-    private static final String COBOL_SET_NORMAL_OR_REVERSE_COMPARE =
-            "           SET %1$s%2$s-COMPARE TO %3$s";
+    private static final String COBOL_SET_NORMAL_OR_REVERSE_COMPARE = "           SET %1$s%2$s-COMPARE TO %3$s";
 
-    private static final String COBOL_SET_COMPARE_NUMERIC =
-            "           SET %1$sNUMERIC-COMPARE TO %2$s";
-    private static final String COBOL_SET_COMPARE_88_LEVEL =
-            "           SET %1$sCOMPARE-88-LEVEL TO %2$s";
+    private static final String COBOL_SET_COMPARE_NUMERIC = "           SET %1$sNUMERIC-COMPARE TO %2$s";
+    private static final String COBOL_SET_COMPARE_88_LEVEL = "           SET %1$sCOMPARE-88-LEVEL TO %2$s";
 
     /**
      * Example: This will look like:
@@ -120,71 +109,40 @@ public class TestSuiteParser {
      * SET UT-RELATION-LT for "less than"
      * SET UT-RELATION-EQ for "equal to"
      */
-    private static final String COBOL_SET_RELATION =
-            "           SET %1$sRELATION-%2$s TO %3$s";
+    private static final String COBOL_SET_RELATION = "           SET %1$sRELATION-%2$s TO %3$s";
 
-    private static final String COBOL_MOVE_FIELDNAME_TO_ACTUAL =
-            "           MOVE %2$s TO %1$sACTUAL";
-    private static final String COBOL_MOVE_FIELDNAME_TO_ACTUAL_NUMERIC =
-            "           MOVE %2$s TO %1$sACTUAL-NUMERIC";
-    private static final String COBOL_MOVE_EXPECTED_ALPHANUMERIC_LITERAL_1 =
-            "           MOVE %s";
-    private static final String COBOL_MOVE_EXPECTED_ALPHANUMERIC_LITERAL_2 =
-            "               TO %sEXPECTED";
-    private static final String COBOL_MOVE_EXPECTED_NUMERIC_LITERAL =
-            "           MOVE %2$s TO %1$sEXPECTED-NUMERIC";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_1 =
-            "           IF %1$s";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_2 =
-            "               SET %1$sACTUAL-88-VALUE TO TRUE";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_3 =
-            "               MOVE 'TRUE' TO %1$sACTUAL";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_4 =
-            "           ELSE";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_5 =
-            "               SET %1$sACTUAL-88-VALUE TO FALSE";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_6 =
-            "               MOVE 'FALSE' TO %1$sACTUAL";
-    private static final String COBOL_SET_ACTUAL_88_VALUE_7 =
-            "           END-IF";
+    private static final String COBOL_MOVE_FIELDNAME_TO_ACTUAL = "           MOVE %2$s TO %1$sACTUAL";
+    private static final String COBOL_MOVE_FIELDNAME_TO_ACTUAL_NUMERIC = "           MOVE %2$s TO %1$sACTUAL-NUMERIC";
+    private static final String COBOL_MOVE_EXPECTED_ALPHANUMERIC_LITERAL_1 = "           MOVE %s";
+    private static final String COBOL_MOVE_EXPECTED_ALPHANUMERIC_LITERAL_2 = "               TO %sEXPECTED";
+    private static final String COBOL_MOVE_EXPECTED_NUMERIC_LITERAL = "           MOVE %2$s TO %1$sEXPECTED-NUMERIC";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_1 = "           IF %1$s";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_2 = "               SET %1$sACTUAL-88-VALUE TO TRUE";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_3 = "               MOVE 'TRUE' TO %1$sACTUAL";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_4 = "           ELSE";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_5 = "               SET %1$sACTUAL-88-VALUE TO FALSE";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_6 = "               MOVE 'FALSE' TO %1$sACTUAL";
+    private static final String COBOL_SET_ACTUAL_88_VALUE_7 = "           END-IF";
 
-    private static final String COBOL_SET_EXPECTED_88_VALUE_1 =
-            "           IF %1s %2$sEXPECTED-88-VALUE";
-    private static final String COBOL_SET_EXPECTED_88_VALUE_2 =
-            "               MOVE 'TRUE' TO %1$sEXPECTED";
-    private static final String COBOL_SET_EXPECTED_88_VALUE_3 =
-            "           ELSE";
-    private static final String COBOL_SET_EXPECTED_88_VALUE_4 =
-            "               MOVE 'FALSE' TO %1$sEXPECTED";
-    private static final String COBOL_SET_EXPECTED_88_VALUE_5 =
-            "           END-IF";
-    private static final String COBOL_SET_EXPECTED_88_VALUE =
-            "           SET %1$sEXPECTED-88-VALUE TO %2$s";
-    private static final String COBOL_SET_ALPHANUMERIC_COMPARE =
-            "           SET %1$sALPHANUMERIC-COMPARE TO %2$s";
-    private static final String COBOL_CHECK_EXPECTATION =
-            "           PERFORM %sCHECK-EXPECTATION";
-    private static final String COBOL_PERFORM_AFTER =
-            "           PERFORM %sAFTER-EACH";
+    private static final String COBOL_SET_EXPECTED_88_VALUE_1 = "           IF %1s %2$sEXPECTED-88-VALUE";
+    private static final String COBOL_SET_EXPECTED_88_VALUE_2 = "               MOVE 'TRUE' TO %1$sEXPECTED";
+    private static final String COBOL_SET_EXPECTED_88_VALUE_3 = "           ELSE";
+    private static final String COBOL_SET_EXPECTED_88_VALUE_4 = "               MOVE 'FALSE' TO %1$sEXPECTED";
+    private static final String COBOL_SET_EXPECTED_88_VALUE_5 = "           END-IF";
+    private static final String COBOL_SET_EXPECTED_88_VALUE = "           SET %1$sEXPECTED-88-VALUE TO %2$s";
+    private static final String COBOL_SET_ALPHANUMERIC_COMPARE = "           SET %1$sALPHANUMERIC-COMPARE TO %2$s";
+    private static final String COBOL_CHECK_EXPECTATION = "           PERFORM %sCHECK-EXPECTATION";
+    private static final String COBOL_PERFORM_AFTER = "           PERFORM %sAFTER-EACH";
     private static final String ELEVEN_LEADING_SPACES = "           ";
 
-    private static final String COBOL_SET_ACTUAL_MOCK_ACCESSES =
-            "           MOVE %1$s TO %2$sACTUAL-ACCESSES";
-    private static final String COBOL_SET_EXPECTED_MOCK_ACCESSES =
-            "           MOVE %1$s TO %2$sEXPECTED-ACCESSES";
-    private static final String COBOL_SET_MOCK_OPERATION =
-            "           MOVE %1$s TO %2$sMOCK-OPERATION";
-    private static final String COBOL_SET_VERIFY_EXACT =
-            "           SET %1$sVERIFY-EXACT TO %2$s";
-    private static final String COBOL_SET_VERIFY_AT_LEAST =
-            "           SET %1$sVERIFY-AT-LEAST TO %2$s";
-    private static final String COBOL_SET_VERIFY_NO_MORE_THAN =
-            "           SET %1$sVERIFY-NO-MORE-THAN TO %2$s";
-    private static final String COBOL_PERFORM_ASSERT_ACCESS =
-            "           PERFORM %1$sASSERT-ACCESSES";
-    private static final String COBOL_MOVE =
-            "           MOVE %1$s TO %2$s";
-
+    private static final String COBOL_SET_ACTUAL_MOCK_ACCESSES = "           MOVE %1$s TO %2$sACTUAL-ACCESSES";
+    private static final String COBOL_SET_EXPECTED_MOCK_ACCESSES = "           MOVE %1$s TO %2$sEXPECTED-ACCESSES";
+    private static final String COBOL_SET_MOCK_OPERATION = "           MOVE %1$s TO %2$sMOCK-OPERATION";
+    private static final String COBOL_SET_VERIFY_EXACT = "           SET %1$sVERIFY-EXACT TO %2$s";
+    private static final String COBOL_SET_VERIFY_AT_LEAST = "           SET %1$sVERIFY-AT-LEAST TO %2$s";
+    private static final String COBOL_SET_VERIFY_NO_MORE_THAN = "           SET %1$sVERIFY-NO-MORE-THAN TO %2$s";
+    private static final String COBOL_PERFORM_ASSERT_ACCESS = "           PERFORM %1$sASSERT-ACCESSES";
+    private static final String COBOL_MOVE = "           MOVE %1$s TO %2$s";
 
     private static final String RELATION_EQ = "EQ";
     private static final String RELATION_GT = "GT";
@@ -195,7 +153,8 @@ public class TestSuiteParser {
     private StringBuffer cobolStatement;
     private NumericFields numericFields;
 
-    public TestSuiteParser(KeywordExtractor keywordExtractor, MockRepository mockRepository, BeforeAfterRepo beforeAfterRepo,
+    public TestSuiteParser(KeywordExtractor keywordExtractor, MockRepository mockRepository,
+                           BeforeAfterRepo beforeAfterRepo,
                            TestSuiteErrorLog testSuiteErrorLog) {
         this.keywordExtractor = keywordExtractor;
         this.mockRepository = mockRepository;
@@ -208,10 +167,12 @@ public class TestSuiteParser {
     }
 
     /**
-     * Process the test suite as a series of tokens. When we have processed all the input, getNextTokenFromTestSuite()
+     * Process the test suite as a series of tokens. When we have processed all the
+     * input, getNextTokenFromTestSuite()
      * returns a null reference.
-     *  @param testSuiteReader - reader attached to the concatenated test suite files.
      *
+     * @param testSuiteReader - reader attached to the concatenated test suite
+     *                        files.
      */
     public List<String> getParsedTestSuiteLines(BufferedReader testSuiteReader,
                                                 NumericFields numericFieldsList) {
@@ -223,16 +184,19 @@ public class TestSuiteParser {
                 testSuiteToken = testSuiteToken.toUpperCase(Locale.ROOT);
             }
 
-            if (Constants.IGNORED_TOKENS.contains(testSuiteToken)){
+            if (Constants.IGNORED_TOKENS.contains(testSuiteToken)) {
                 testSuiteToken = getNextTokenFromTestSuite(testSuiteReader);
                 continue;
             }
 
-            boolean cobolTokenIsFieldName = (expectInProgress || expectQualifiedName || expectMockIdentifier || (expectMockArguments && !expectUsing));
+            boolean cobolTokenIsFieldName = (expectInProgress || expectQualifiedName || expectMockIdentifier
+                    || (expectMockArguments && !expectUsing));
             Keyword keyword = Keywords.getKeywordFor(testSuiteToken, cobolTokenIsFieldName);
 
-            if (!verifyInProgress && expectUsing && expectMockArguments && !keyword.value().equals(Constants.USING_TOKEN)){
-                //In this case we expected mock arguments, but got none. We end the mock and go to next token
+            if (!verifyInProgress && expectUsing && expectMockArguments
+                    && !keyword.value().equals(Constants.USING_TOKEN)) {
+                // In this case we expected mock arguments, but got none. We end the mock and go
+                // to next token
                 expectMockArguments = false;
                 expectUsing = false;
                 handleEndOfMockStatement(testSuiteReader, testSuiteToken, false);
@@ -240,7 +204,8 @@ public class TestSuiteParser {
                 continue;
             }
 
-            if (!testSuiteErrorLog.checkExpectedTokenSyntax(keyword, testSuiteToken, currentTestSuiteRealFile, fileLineNumber, fileLineIndexNumber)){
+            if (!testSuiteErrorLog.checkExpectedTokenSyntax(keyword, testSuiteToken, currentTestSuiteRealFile,
+                    fileLineNumber, fileLineIndexNumber)) {
                 testSuiteToken = getNextTokenFromTestSuite(testSuiteReader);
                 continue;
             }
@@ -271,10 +236,9 @@ public class TestSuiteParser {
                     break;
 
                 case Constants.NOT_KEYWORD:
-                    if (expectInProgress){
+                    if (expectInProgress) {
                         reverseCompare = true;
-                    }
-                    else if (cobolStatementInProgress) {
+                    } else if (cobolStatementInProgress) {
                         appendTokenToCobolStatement(testSuiteToken);
                     }
                     break;
@@ -295,8 +259,7 @@ public class TestSuiteParser {
                         expectInProgress = false;
                         toBeInProgress = true;
                         greaterThanComparison = true;
-                    }
-                    else if (cobolStatementInProgress) {
+                    } else if (cobolStatementInProgress) {
                         appendTokenToCobolStatement(testSuiteToken);
                     }
                     break;
@@ -307,8 +270,7 @@ public class TestSuiteParser {
                         expectInProgress = false;
                         toBeInProgress = true;
                         lessThanComparison = true;
-                    }
-                    else if (cobolStatementInProgress) {
+                    } else if (cobolStatementInProgress) {
                         appendTokenToCobolStatement(testSuiteToken);
                     }
                     break;
@@ -324,8 +286,7 @@ public class TestSuiteParser {
                         } else {
                             reverseCompare = true;
                         }
-                    }
-                    else if (cobolStatementInProgress) {
+                    } else if (cobolStatementInProgress) {
                         appendTokenToCobolStatement(testSuiteToken);
                     }
                     break;
@@ -337,8 +298,7 @@ public class TestSuiteParser {
                         toBeInProgress = true;
                         greaterThanComparison = true;
                         reverseCompare = !reverseCompare;
-                    }
-                    else if (cobolStatementInProgress) {
+                    } else if (cobolStatementInProgress) {
                         appendTokenToCobolStatement(testSuiteToken);
                     }
                     break;
@@ -350,23 +310,22 @@ public class TestSuiteParser {
 
                 case Constants.COBOL_TOKEN:
                 case Constants.FIELDNAME_KEYWORD:
-                    //TODO:remove when implementing EXPECT NUMERIC
-                    if (testSuiteToken.equals("NUMERIC")){
-                        Log.debug("==WARNING== <EXPECT ... TO BE NUMERIC ...> is not implemented and could cause unintended behaviour ==WARNING==");
+                    // TODO:remove when implementing EXPECT NUMERIC
+                    if (testSuiteToken.equals("NUMERIC")) {
+                        Log.debug(
+                                "==WARNING== <EXPECT ... TO BE NUMERIC ...> is not implemented and could cause unintended behaviour ==WARNING==");
                         ignoreCobolStatementAndFieldNameKeyAction = true;
                         break;
                     }
                     if (expectQualifiedName) {
                         fieldNameForExpect += testSuiteToken;
                         expectQualifiedName = false;
-                    }
-                    else if (possibleQualifiedName) {
+                    } else if (possibleQualifiedName) {
                         if (qualifiedNameKeywords.contains(testSuiteToken)) {
                             fieldNameForExpect += Constants.SPACE + testSuiteToken + Constants.SPACE;
                             expectQualifiedName = true;
                         }
-                    }
-                    else if (expectInProgress) {
+                    } else if (expectInProgress) {
                         fieldNameForExpect = testSuiteToken;
                         possibleQualifiedName = true;
                     }
@@ -375,34 +334,20 @@ public class TestSuiteParser {
                         addTestCodeForAssertion(parsedTestSuiteLines, numericFields);
                         toBeInProgress = false;
                     }
-                    if (expectMockIdentifier){
+                    if (expectMockIdentifier) {
                         expectMockIdentifier = false;
                         ignoreCobolStatementAndFieldNameKeyAction = true;
-                        if (!verifyInProgress){
-                            if (currentMock.getType().equals(Constants.CALL_TOKEN)){
+                        if (!verifyInProgress) {
+                            if (currentMock.getType().equals(Constants.CALL_TOKEN)) {
                                 expectUsing = true;
                                 expectMockArguments = true;
                             }
                             currentMock.setIdentifier(testSuiteToken);
                             if (!expectMockArguments) {
-                                List<String> mockLines = getLinesUntilKeywordHit(testSuiteReader, Constants.ENDMOCK_KEYWORD, testSuiteToken, true);
-                                //We know END-MOCK is reached here
-                                testSuiteErrorLog.checkSyntaxInsideBlock(Constants.MOCK_KEYWORD, mockLines, keywordExtractor,
-                                        currentTestSuiteRealFile, fileLineNumber);
-                                Keyword endMockKeyword = Keywords.getKeywordFor(Constants.ENDMOCK_KEYWORD, false);
-                                testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile, fileLineNumber,
-                                        currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
-                                currentMock.addLines(mockLines);
-                                try{
-                                    mockRepository.addMock(currentMock);
-                                } catch (ComponentMockedTwiceInSameScopeException e){
-                                    testSuiteErrorLog.logIdenticalMocks(currentMock);
-                                }
-
+                                handleEndOfMockStatement(testSuiteReader, testSuiteToken, true);
                             }
-                        }
-                        else {
-                            if (currentVerify.getType().equals(Constants.CALL_TOKEN)){
+                        } else {
+                            if (currentVerify.getType().equals(Constants.CALL_TOKEN)) {
                                 expectUsing = true;
                                 expectMockArguments = true;
                             }
@@ -411,9 +356,9 @@ public class TestSuiteParser {
                         break;
                     }
 
-                    if (expectMockArguments){
+                    if (expectMockArguments) {
                         boolean currentLineContainsArgument = false;
-                        if (!expectUsing){
+                        if (!expectUsing) {
                             currentLineContainsArgument = true;
                             ignoreCobolStatementAndFieldNameKeyAction = true;
                             if (verifyInProgress)
@@ -425,28 +370,17 @@ public class TestSuiteParser {
                             if (testSuiteToken.endsWith(","))
                                 break;
                         }
-                        //Contains no arguments or all arguments has been added
+                        // Contains no arguments or all arguments has been added
                         expectMockArguments = false;
                         expectUsing = false;
-                        if (!verifyInProgress){
+                        if (!verifyInProgress) {
                             ignoreCobolStatementAndFieldNameKeyAction = true;
-                            List<String> mockLines = getLinesUntilKeywordHit(testSuiteReader, Constants.ENDMOCK_KEYWORD, testSuiteToken, currentLineContainsArgument);
-                            testSuiteErrorLog.checkSyntaxInsideBlock(Constants.MOCK_KEYWORD, mockLines, keywordExtractor,
-                                    currentTestSuiteRealFile, fileLineNumber);
-                            Keyword endMockKeyword = Keywords.getKeywordFor(Constants.ENDMOCK_KEYWORD, false);
-                            testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile, fileLineNumber,
-                                    currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
-                            currentMock.addLines(removeToken(mockLines, "END-CALL"));
-                            try{
-                                mockRepository.addMock(currentMock);
-                            } catch (ComponentMockedTwiceInSameScopeException e){
-                                testSuiteErrorLog.logIdenticalMocks(currentMock);
-                            }
+                            handleEndOfMockStatement(testSuiteReader, testSuiteToken, currentLineContainsArgument);
                         }
                     }
 
-                    if (verifyInProgress){
-                        if (testSuiteToken.equalsIgnoreCase(Constants.ZERO_TOKEN)){
+                    if (verifyInProgress) {
+                        if (testSuiteToken.equalsIgnoreCase(Constants.ZERO_TOKEN)) {
                             currentVerify.setExpectedCount("0");
                         }
                     }
@@ -467,32 +401,19 @@ public class TestSuiteParser {
                         addTestCaseNameLines(currentTestCaseName, parsedTestSuiteLines);
                         initializeCobolStatement();
                     }
-                    if (expectMockIdentifier){
+                    if (expectMockIdentifier) {
                         expectMockIdentifier = false;
-                        if (!verifyInProgress){
-                            if (currentMock.getType().equals(Constants.CALL_TOKEN)){
+                        if (!verifyInProgress) {
+                            if (currentMock.getType().equals(Constants.CALL_TOKEN)) {
                                 expectUsing = true;
                                 expectMockArguments = true;
                             }
                             currentMock.setIdentifier(testSuiteToken);
                             if (!expectMockArguments) {
-                                List<String> mockLines = getLinesUntilKeywordHit(testSuiteReader, Constants.ENDMOCK_KEYWORD, testSuiteToken, true);
-                                //We know END-MOCK is reached here
-                                testSuiteErrorLog.checkSyntaxInsideBlock(Constants.MOCK_KEYWORD, mockLines, keywordExtractor,
-                                        currentTestSuiteRealFile, fileLineNumber);
-                                Keyword endMockKeyword = Keywords.getKeywordFor(Constants.ENDMOCK_KEYWORD, false);
-                                testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile, fileLineNumber,
-                                        currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
-                                currentMock.addLines(mockLines);
-                                try{
-                                    mockRepository.addMock(currentMock);
-                                } catch (ComponentMockedTwiceInSameScopeException e){
-                                    testSuiteErrorLog.logIdenticalMocks(currentMock);
-                                }
+                                handleEndOfMockStatement(testSuiteReader, testSuiteToken, true);
                             }
-                        }
-                        else {
-                            if (currentVerify.getType().equals(Constants.CALL_TOKEN)){
+                        } else {
+                            if (currentVerify.getType().equals(Constants.CALL_TOKEN)) {
                                 expectUsing = true;
                                 expectMockArguments = true;
                             }
@@ -501,7 +422,8 @@ public class TestSuiteParser {
                         break;
                     }
                     if (toBeInProgress) {
-                        if (testSuiteToken.startsWith(Constants.QUOTE) || testSuiteToken.startsWith(Constants.APOSTROPHE)) {
+                        if (testSuiteToken.startsWith(Constants.QUOTE)
+                                || testSuiteToken.startsWith(Constants.APOSTROPHE)) {
                             expectedValueToCompare = testSuiteToken;
                             addTestCodeForAssertion(parsedTestSuiteLines, numericFields);
                         }
@@ -515,7 +437,7 @@ public class TestSuiteParser {
                         addTestCodeForAssertion(parsedTestSuiteLines, numericFields);
                         toBeInProgress = false;
                     }
-                    if (verifyInProgress){
+                    if (verifyInProgress) {
                         currentVerify.setExpectedCount(testSuiteToken);
                     }
                     break;
@@ -539,22 +461,26 @@ public class TestSuiteParser {
 
                 case Constants.BEFORE_EACH_TOKEN:
                 case Constants.BEFORE_EACH_TOKEN_HYPHEN:
-                    List<String> beforeLines = getLinesUntilKeywordHit(testSuiteReader, Constants.END_BEFORE_TOKEN, testSuiteToken, true);
+                    List<String> beforeLines = getLinesUntilKeywordHit(testSuiteReader, Constants.END_BEFORE_TOKEN,
+                            testSuiteToken, true);
                     testSuiteErrorLog.checkSyntaxInsideBlock(Constants.BEFORE_EACH_TOKEN, beforeLines, keywordExtractor,
                             currentTestSuiteRealFile, fileLineNumber);
                     Keyword endBeforeKeyword = Keywords.getKeywordFor(Constants.END_BEFORE_TOKEN, false);
-                    testSuiteErrorLog.checkExpectedTokenSyntax(endBeforeKeyword, testSuiteToken, currentTestSuiteRealFile, fileLineNumber,
+                    testSuiteErrorLog.checkExpectedTokenSyntax(endBeforeKeyword, testSuiteToken,
+                            currentTestSuiteRealFile, fileLineNumber,
                             currentTestSuiteLine.indexOf(Constants.END_BEFORE_TOKEN));
                     beforeAfterRepo.addBeforeEachItem(testSuiteNumber, currentTestSuiteName, beforeLines);
                     break;
 
                 case Constants.AFTER_EACH_TOKEN:
                 case Constants.AFTER_EACH_TOKEN_HYPHEN:
-                    List<String> afterLines = getLinesUntilKeywordHit(testSuiteReader, Constants.END_AFTER_TOKEN, testSuiteToken, true);
+                    List<String> afterLines = getLinesUntilKeywordHit(testSuiteReader, Constants.END_AFTER_TOKEN,
+                            testSuiteToken, true);
                     testSuiteErrorLog.checkSyntaxInsideBlock(Constants.AFTER_EACH_TOKEN, afterLines, keywordExtractor,
                             currentTestSuiteRealFile, fileLineNumber);
                     Keyword endAfterKeyword = Keywords.getKeywordFor(Constants.END_AFTER_TOKEN, false);
-                    testSuiteErrorLog.checkExpectedTokenSyntax(endAfterKeyword, testSuiteToken, currentTestSuiteRealFile, fileLineNumber,
+                    testSuiteErrorLog.checkExpectedTokenSyntax(endAfterKeyword, testSuiteToken,
+                            currentTestSuiteRealFile, fileLineNumber,
                             currentTestSuiteLine.indexOf(Constants.END_AFTER_TOKEN));
                     beforeAfterRepo.addAfterEachItem(testSuiteNumber, currentTestSuiteName, afterLines);
                     break;
@@ -567,10 +493,9 @@ public class TestSuiteParser {
                     mockNumber += 1;
                     currentMock = new Mock(currentTestSuiteName, currentTestCaseName,
                             testSuiteNumber, testCaseNumber, mockNumber);
-                    if (testCaseNumber == 0){
+                    if (testCaseNumber == 0) {
                         currentMock.setScope(MockScope.Global);
-                    }
-                    else {
+                    } else {
                         currentMock.setScope(MockScope.Local);
                     }
                     currentMock.setTestSuiteFileName(currentTestSuiteRealFile);
@@ -580,15 +505,14 @@ public class TestSuiteParser {
 
                 case Constants.MOCK_TYPE:
                     expectMockIdentifier = true;
-                    //TODO: REMOVE PARA
-                    if (testSuiteToken.equals(Constants.PARA_TOKEN)){
+                    // TODO: REMOVE PARA
+                    if (testSuiteToken.equals(Constants.PARA_TOKEN)) {
                         testSuiteToken = Constants.PARAGRAPH_TOKEN;
                     }
 
-                    if (!verifyInProgress){
+                    if (!verifyInProgress) {
                         currentMock.setType(testSuiteToken);
-                    }
-                    else {
+                    } else {
                         currentVerify.setType(testSuiteToken);
                     }
 
@@ -635,16 +559,17 @@ public class TestSuiteParser {
                     break;
 
                 case Constants.AT_LEAST_KEYWORD:
-                    //Actual value is set at next token
+                    // Actual value is set at next token
                     currentVerify.expectAtLeast("N/A");
                     break;
 
                 case Constants.NO_MORE_THAN_KEYWORD:
-                    //Actual value is set at next token
+                    // Actual value is set at next token
                     currentVerify.expectNoMoreThan("N/A");
                     break;
 
-                case Constants.TIME_KEYWORD: case Constants.TIMES_KEYWORD:
+                case Constants.TIME_KEYWORD:
+                case Constants.TIMES_KEYWORD:
                     handleEndOfVerifyStatement(parsedTestSuiteLines);
                     break;
 
@@ -657,7 +582,8 @@ public class TestSuiteParser {
                     break;
             }
 
-            // take actions that were triggered by the previous token's action, pertaining to the current token
+            // take actions that were triggered by the previous token's action, pertaining
+            // to the current token
             switch (nextAction) {
                 case TESTSUITE_NAME:
                     currentTestSuiteName = testSuiteToken;
@@ -680,7 +606,7 @@ public class TestSuiteParser {
             // take actions that are triggered by the current token's action
             switch (keyword.keywordAction()) {
                 case COBOL_STATEMENT:
-                    if (ignoreCobolStatementAndFieldNameKeyAction){
+                    if (ignoreCobolStatementAndFieldNameKeyAction) {
                         ignoreCobolStatementAndFieldNameKeyAction = false;
                         break;
                     }
@@ -694,7 +620,7 @@ public class TestSuiteParser {
                     appendTokenToCobolStatement(testSuiteToken);
                     break;
                 case FIELDNAME:
-                    if (ignoreCobolStatementAndFieldNameKeyAction){
+                    if (ignoreCobolStatementAndFieldNameKeyAction) {
                         ignoreCobolStatementAndFieldNameKeyAction = false;
                         break;
                     }
@@ -708,13 +634,14 @@ public class TestSuiteParser {
             nextAction = keyword.keywordAction();
             testSuiteToken = getNextTokenFromTestSuite(testSuiteReader);
         }
-        if (testSuiteErrorLog.hasErrorOccured()){
-            throw new TestSuiteSyntaxException("The test suite(s) contained one or more errors. See the error log for more details");
+        if (testSuiteErrorLog.hasErrorOccured()) {
+            throw new TestSuiteSyntaxException(
+                    "The test suite(s) contained one or more errors. See the error log for more details");
         }
         if (cobolStatementInProgress) {
             addUserWrittenCobolStatement(parsedTestSuiteLines);
         }
-        if (testCaseNumber != 0){
+        if (testCaseNumber != 0) {
             addPerformAfterEachLine(parsedTestSuiteLines);
         }
         return parsedTestSuiteLines;
@@ -722,11 +649,11 @@ public class TestSuiteParser {
 
     private List<String> removeToken(List<String> lines, String token) {
         List<String> newLines = new ArrayList<>();
-        for (String line : lines){
+        for (String line : lines) {
             String upperLine = line.toUpperCase(Locale.ROOT);
             int startIndex = upperLine.indexOf(token.toUpperCase(Locale.ROOT));
             int endIndex = startIndex + token.length();
-            if (startIndex != -1){
+            if (startIndex != -1) {
                 String part1 = line.substring(0, startIndex);
                 String part2 = line.substring(endIndex);
                 line = part1 + part2;
@@ -737,15 +664,23 @@ public class TestSuiteParser {
     }
 
     /**
-     * This method hides file I/O from the test suite parsing logic so the parsing logic will be easier to understand.
-     * We don't want to load the whole test suite into memory at once, as we don't know how large it may be.
-     * Here we consume tokens one by one and invoke the file read routine whenever we exhaust the list of tokens.
-     * When the file read routine returns a null reference, it means we have reached end-of-file on the test suite.
-     * This method uses a keyword extractor instance to get tokens from the input record. "Tokens" in this context
-     * may mean phrases that contain embedded spaces, like "TO BE", and quoted string literals with the quotes intact.
-     * Comment lines are bypassed, as there is no need to insert them into the test program.
+     * This method hides file I/O from the test suite parsing logic so the parsing
+     * logic will be easier to understand.
+     * We don't want to load the whole test suite into memory at once, as we don't
+     * know how large it may be.
+     * Here we consume tokens one by one and invoke the file read routine whenever
+     * we exhaust the list of tokens.
+     * When the file read routine returns a null reference, it means we have reached
+     * end-of-file on the test suite.
+     * This method uses a keyword extractor instance to get tokens from the input
+     * record. "Tokens" in this context
+     * may mean phrases that contain embedded spaces, like "TO BE", and quoted
+     * string literals with the quotes intact.
+     * Comment lines are bypassed, as there is no need to insert them into the test
+     * program.
      *
-     * @param testSuiteReader - reader attached to the concatenated test suite files.
+     * @param testSuiteReader - reader attached to the concatenated test suite
+     *                        files.
      * @return - the next token from the testSuiteReader.
      */
     private String getNextTokenFromTestSuite(BufferedReader testSuiteReader) {
@@ -754,8 +689,8 @@ public class TestSuiteParser {
             if (testSuiteLine == null) {
                 return null;
             }
-            //Finding writing style based on first token in file
-            if (currentTestSuiteRealFile != null && !currentTestSuiteRealFile.equals(oldTestSuiteRealFile)){
+            // Finding writing style based on first token in file
+            if (currentTestSuiteRealFile != null && !currentTestSuiteRealFile.equals(oldTestSuiteRealFile)) {
                 testSuiteWritingStyle = getWritingStyleOfLine(testSuiteLine);
                 Log.debug("Writing style set to " + testSuiteWritingStyle.name() +
                         " for test suite: " + currentTestSuiteRealFile);
@@ -765,9 +700,9 @@ public class TestSuiteParser {
                 testSuiteLine = testSuiteLine.substring(6);
 
             if (testSuiteLine.length() > 0 && !testSuiteLine.trim().startsWith("*")) {
-//            if (testSuiteLine.length() > 5 && testSuiteLine.charAt(6) != '*') {
+                // if (testSuiteLine.length() > 5 && testSuiteLine.charAt(6) != '*') {
                 testSuiteTokens = keywordExtractor.extractTokensFrom(testSuiteLine);
-                while (keywordExtractor.tokenListEndsDuringMultiToken(testSuiteTokens)){
+                while (keywordExtractor.tokenListEndsDuringMultiToken(testSuiteTokens)) {
                     currentTestSuiteLine = StringHelper.removeTrailingSpaces(currentTestSuiteLine) + " " +
                             readNextLineFromTestSuite(testSuiteReader).trim();
                     testSuiteTokens = keywordExtractor.extractTokensFrom(currentTestSuiteLine);
@@ -782,9 +717,11 @@ public class TestSuiteParser {
     }
 
     /**
-     * This method performs the grunt work of reading records from the test suite input source.
+     * This method performs the grunt work of reading records from the test suite
+     * input source.
      *
-     * @param testSuiteReader - reader attached to the concatenated test suite files.
+     * @param testSuiteReader - reader attached to the concatenated test suite
+     *                        files.
      * @return - line of source from the testSuiteReader.
      */
     private String readNextLineFromTestSuite(BufferedReader testSuiteReader) {
@@ -797,8 +734,7 @@ public class TestSuiteParser {
                     throw new PossibleInternalLogicErrorException(Messages.get("ERR010"));
                 }
                 return null;
-            }
-            else if (currentTestSuiteLine.startsWith("      *From file:")){
+            } else if (currentTestSuiteLine.startsWith("      *From file:")) {
                 fileLineNumber = 0;
                 oldTestSuiteRealFile = currentTestSuiteRealFile;
                 currentTestSuiteRealFile = currentTestSuiteLine.substring(currentTestSuiteLine.indexOf(":"));
@@ -813,8 +749,8 @@ public class TestSuiteParser {
         }
     }
 
-    private TestSuiteWritingStyle getWritingStyleOfLine(String line){
-        if (line.length() > 5){
+    private TestSuiteWritingStyle getWritingStyleOfLine(String line) {
+        if (line.length() > 5) {
             String potentialSequenceAreaNumber = line.substring(0, 6);
             Keyword keyword = Keywords.getKeywordFor(potentialSequenceAreaNumber, false);
             if (keyword.value().equals(Constants.NUMERIC_LITERAL_KEYWORD))
@@ -823,38 +759,44 @@ public class TestSuiteParser {
         return TestSuiteWritingStyle.Freeform;
     }
 
-    //TODO: Replace occurences of mock endings with this method!
-    private void handleEndOfMockStatement(BufferedReader testSuiteReader, String testSuiteToken, boolean skipCurrentToken) {
-        List<String> mockLines = getLinesUntilKeywordHit(testSuiteReader, Constants.ENDMOCK_KEYWORD, testSuiteToken, skipCurrentToken);
+    private void handleEndOfMockStatement(BufferedReader testSuiteReader, String testSuiteToken,
+                                          boolean skipCurrentToken) {
+        List<String> mockLines = getLinesUntilKeywordHit(testSuiteReader, Constants.ENDMOCK_KEYWORD, testSuiteToken,
+                skipCurrentToken);
         testSuiteErrorLog.checkSyntaxInsideBlock(Constants.MOCK_KEYWORD, mockLines, keywordExtractor,
                 currentTestSuiteRealFile, fileLineNumber);
         Keyword endMockKeyword = Keywords.getKeywordFor(Constants.ENDMOCK_KEYWORD, false);
-        testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile, fileLineNumber,
+        testSuiteErrorLog.checkExpectedTokenSyntax(endMockKeyword, Constants.ENDMOCK_KEYWORD, currentTestSuiteRealFile,
+                fileLineNumber,
                 currentTestSuiteLine.indexOf(Constants.ENDMOCK_KEYWORD));
-        if (currentMock.getType() == Constants.CALL_TOKEN)
+        if (currentMock.getType().equals(Constants.CALL_TOKEN))
             currentMock.addLines(removeToken(mockLines, "END-CALL"));
         else
             currentMock.addLines(mockLines);
-        try{
+        try {
             mockRepository.addMock(currentMock);
-        } catch (ComponentMockedTwiceInSameScopeException e){
+        } catch (ComponentMockedTwiceInSameScopeException e) {
             testSuiteErrorLog.logIdenticalMocks(currentMock);
         }
     }
 
     /**
-     * Finds the mock, that the current verify statement is referencing and attaches it.
+     * Finds the mock, that the current verify statement is referencing and attaches
+     * it.
      * Generates lines for verify statement and adds them to the given list.
-     * @param parsedTestSuiteLines The parsed lines, that the generated lines are appended to
-     * @throws VerifyReferencesNonexistentMockException if referenced mock, does not exist
+     *
+     * @param parsedTestSuiteLines The parsed lines, that the generated lines are
+     *                             appended to
      * @return - the next token from the testSuiteReader.
+     * @throws VerifyReferencesNonexistentMockException if referenced mock, does not
+     *                                                  exist
      */
-    public void handleEndOfVerifyStatement (List<String> parsedTestSuiteLines){
+    public void handleEndOfVerifyStatement(List<String> parsedTestSuiteLines) {
         verifyInProgress = false;
         currentVerify.setAttachedMock(mockRepository.getMockFor(currentVerify.getIdentifier(), currentVerify.getType(),
                 currentTestSuiteName, currentTestCaseName, currentVerify.getArguments()));
 
-        if (currentVerify.getAttachedMock() == null){
+        if (currentVerify.getAttachedMock() == null) {
             testSuiteErrorLog.logVerifyReferencesNonExistentMock(currentVerify);
             throw new VerifyReferencesNonexistentMockException("Cannot verify nonexistent mock for: " +
                     currentVerify.getType() + " " + currentVerify.getIdentifier() + " in the scope of testsuite: " +
@@ -864,11 +806,15 @@ public class TestSuiteParser {
     }
 
     /**
-     * Gets an argument for a call based on the given reference type and token. If the
-     * reference type is empty, the default ref-type (REFERENCE) will be assigned. All commas
+     * Gets an argument for a call based on the given reference type and token. If
+     * the
+     * reference type is empty, the default ref-type (REFERENCE) will be assigned.
+     * All commas
      * is removed in the returned argument.
-     * @param referenceType The ref-type of the argument. Can be REFERENCE, CONTENT or VALUE
-     * @param value The value/variable given as argument
+     *
+     * @param referenceType The ref-type of the argument. Can be REFERENCE, CONTENT
+     *                      or VALUE
+     * @param value         The value/variable given as argument
      * @return - The argument in the format '[ref-type] [value]'
      */
     private String getCallArgument(String referenceType, String value) {
@@ -880,7 +826,8 @@ public class TestSuiteParser {
         return outPut;
     }
 
-    // Helper methods to insert code into the test program being generated based on interpretation of user-written
+    // Helper methods to insert code into the test program being generated based on
+    // interpretation of user-written
     // test case code.
 
     public String getTestInitializationLine() {
@@ -975,12 +922,11 @@ public class TestSuiteParser {
         String oldExpectedValueToCompare = expectedValueToCompare;
         parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_88_VALUE, testCodePrefix, expectedValueToCompare));
         if (reverseCompare) {
-            parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_88_VALUE_1, Constants.NOT_KEYWORD, testCodePrefix));
-        }
-        else {
+            parsedTestSuiteLines
+                    .add(String.format(COBOL_SET_EXPECTED_88_VALUE_1, Constants.NOT_KEYWORD, testCodePrefix));
+        } else {
             parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_88_VALUE_1, "", testCodePrefix));
         }
-
 
         parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_88_VALUE_2, testCodePrefix));
         parsedTestSuiteLines.add(COBOL_SET_EXPECTED_88_VALUE_3);
@@ -990,7 +936,8 @@ public class TestSuiteParser {
     }
 
     /**
-     * Writes a Cobol source statement of the form SET XX-NORMAL-COMPARE TO TRUE or SET XX-REVERSE-COMPARE TO TRUE
+     * Writes a Cobol source statement of the form SET XX-NORMAL-COMPARE TO TRUE or
+     * SET XX-REVERSE-COMPARE TO TRUE
      * depending on whether NOT was specified in an EXPECT specification.
      *
      * @param parsedTestSuiteLines - The lines that are parsed from the testsuites
@@ -1004,36 +951,34 @@ public class TestSuiteParser {
     }
 
     void addLinesForCurrentVerifyStatement(List<String> parsedTestSuiteLines) {
-            parsedTestSuiteLines.add(String.format(COBOL_MOVE, currentVerify.getExpectedCount(),
-                    currentVerify.getAttachedMock().getGeneratedMockCountExpectedIdentifier()));
+        parsedTestSuiteLines.add(String.format(COBOL_MOVE, currentVerify.getExpectedCount(),
+                currentVerify.getAttachedMock().getGeneratedMockCountExpectedIdentifier()));
 
-            parsedTestSuiteLines.add(String.format(COBOL_SET_ACTUAL_MOCK_ACCESSES,
-                    currentVerify.getAttachedMock().getGeneratedMockCountIdentifier(), testCodePrefix));
-            parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_MOCK_ACCESSES,
-                    currentVerify.getAttachedMock().getGeneratedMockCountExpectedIdentifier(), testCodePrefix));
-            parsedTestSuiteLines.add(String.format(COBOL_SET_MOCK_OPERATION,
-                    currentVerify.getAttachedMock().getGeneratedMockStringIdentifierName(), testCodePrefix));
+        parsedTestSuiteLines.add(String.format(COBOL_SET_ACTUAL_MOCK_ACCESSES,
+                currentVerify.getAttachedMock().getGeneratedMockCountIdentifier(), testCodePrefix));
+        parsedTestSuiteLines.add(String.format(COBOL_SET_EXPECTED_MOCK_ACCESSES,
+                currentVerify.getAttachedMock().getGeneratedMockCountExpectedIdentifier(), testCodePrefix));
+        parsedTestSuiteLines.add(String.format(COBOL_SET_MOCK_OPERATION,
+                currentVerify.getAttachedMock().getGeneratedMockStringIdentifierName(), testCodePrefix));
 
-            //Set comparison
-            if (currentVerify.isSetToAtLeast()){
-                parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_AT_LEAST, testCodePrefix, "TRUE"));
+        // Set comparison
+        if (currentVerify.isSetToAtLeast()) {
+            parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_AT_LEAST, testCodePrefix, "TRUE"));
+        } else {
+            if (currentVerify.isSetToNoMoreThan()) {
+                parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_NO_MORE_THAN, testCodePrefix, "TRUE"));
+            } else {
+                parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_EXACT, testCodePrefix, "TRUE"));
             }
-            else{
-                if (currentVerify.isSetToNoMoreThan()){
-                    parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_NO_MORE_THAN, testCodePrefix, "TRUE"));
-                }
-                else {
-                    parsedTestSuiteLines.add(String.format(COBOL_SET_VERIFY_EXACT, testCodePrefix, "TRUE"));
-                }
 
-            }
-            parsedTestSuiteLines.add(String.format(COBOL_INCREMENT_TEST_CASE_COUNT, testCodePrefix));
-            parsedTestSuiteLines.add(String.format(COBOL_PERFORM_ASSERT_ACCESS, testCodePrefix));
+        }
+        parsedTestSuiteLines.add(String.format(COBOL_INCREMENT_TEST_CASE_COUNT, testCodePrefix));
+        parsedTestSuiteLines.add(String.format(COBOL_PERFORM_ASSERT_ACCESS, testCodePrefix));
     }
 
-
     /**
-     * Writes the final lines of Cobol for a test case, common to different kinds of test cases.
+     * Writes the final lines of Cobol for a test case, common to different kinds of
+     * test cases.
      *
      * @param parsedTestSuiteLines - The lines that are parsed from the testsuites
      */
@@ -1042,15 +987,19 @@ public class TestSuiteParser {
     }
 
     /**
-     * Generator compiles a list of Data Division item names from the program under test that represent numeric
-     * data types. This method returns true when the item name of the "actual" field in an EXPECT specification
+     * Generator compiles a list of Data Division item names from the program under
+     * test that represent numeric
+     * data types. This method returns true when the item name of the "actual" field
+     * in an EXPECT specification
      * is in that list.
      *
-     * @param fieldNameForExpect - the field name of the "actual" reference in an EXPECT specification
+     * @param fieldNameForExpect - the field name of the "actual" reference in an
+     *                           EXPECT specification
      * @return true when the field name represents any numeric data type
      */
     boolean fieldIsANumericDataType(String fieldNameForExpect) {
-        // Remove potential qualifiers and indexing, so we only get the single field name.
+        // Remove potential qualifiers and indexing, so we only get the single field
+        // name.
         if (fieldNameForExpect != null && !fieldNameForExpect.isEmpty())
             fieldNameForExpect = fieldNameForExpect.split(" ")[0];
 
@@ -1061,19 +1010,22 @@ public class TestSuiteParser {
 
     /**
      * Build a Cobol statement out of tokens from the test suite input.
-     * Users may code standard Cobol statements to set up preconditions for a test case.
+     * Users may code standard Cobol statements to set up preconditions for a test
+     * case.
      * These tokens may occur immediately following the test case name string.
      * Users may code standard Cobol statements to define the behavior of a MOCK.
      *
      * @param testSuiteToken - token extracted from test suit input
      */
     void appendTokenToCobolStatement(String testSuiteToken) {
-        if (cobolStatement.length() > 0) cobolStatement.append(Constants.SPACE);
+        if (cobolStatement.length() > 0)
+            cobolStatement.append(Constants.SPACE);
         cobolStatement.append(testSuiteToken);
     }
 
     /**
-     * Insert user-written Cobol statement from a test suite (not from the program under test) into the test program
+     * Insert user-written Cobol statement from a test suite (not from the program
+     * under test) into the test program
      * being generated.
      *
      * @param parsedTestSuiteLines - The lines that are parsed from the testsuites
@@ -1082,32 +1034,27 @@ public class TestSuiteParser {
         parsedTestSuiteLines.add(cobolStatement.toString());
     }
 
-    private List<String> getLinesUntilKeywordHit(BufferedReader testSuiteReader, String endingKeyword, String currentKey, boolean skipCurrentToken){
+    private List<String> getLinesUntilKeywordHit(BufferedReader testSuiteReader, String endingKeyword,
+                                                 String currentKey, boolean skipCurrentToken) {
         List<String> lines = new ArrayList<>();
-        //Find the remaining tokens on the current line
-        if (skipCurrentToken){
+        // Find the remaining tokens on the current line
+        if (skipCurrentToken) {
             int index = fileLineIndexNumber + currentKey.length() - 1;
-            if (index < currentTestSuiteLine.length())
-            {
+            if (index < currentTestSuiteLine.length()) {
                 currentTestSuiteLine = "           " + currentTestSuiteLine.substring(index);
-            }
-            else
+            } else
                 currentTestSuiteLine = "";
-        }
-        else{
+        } else {
             int index = fileLineIndexNumber - 1;
-            if (index < currentTestSuiteLine.length())
-            {
+            if (index < currentTestSuiteLine.length()) {
                 currentTestSuiteLine = "           " + currentTestSuiteLine.substring(index);
-            }
-            else
+            } else
                 currentTestSuiteLine = "";
         }
-        if (!currentTestSuiteLine.trim().isEmpty())
-        {
+        if (!currentTestSuiteLine.trim().isEmpty()) {
             lines.add(currentTestSuiteLine);
         }
-        if(currentTestSuiteLine.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))){
+        if (currentTestSuiteLine.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))) {
             String line = lines.get(0);
             int startIndex = line.toUpperCase(Locale.ROOT).indexOf(endingKeyword);
             int endIndex = startIndex + endingKeyword.length();
@@ -1122,12 +1069,12 @@ public class TestSuiteParser {
         }
         String line;
         while ((line = readNextLineFromTestSuite(testSuiteReader)) != null &&
-                !line.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))){
+                !line.toUpperCase(Locale.ROOT).contains(endingKeyword.toUpperCase(Locale.ROOT))) {
             lines.add(line);
         }
         int startIndex = line.toUpperCase(Locale.ROOT).indexOf(endingKeyword);
         int endIndex = startIndex + endingKeyword.length();
-        String lineToAdd =  line.substring(0, startIndex);
+        String lineToAdd = line.substring(0, startIndex);
         if (!lineToAdd.trim().isEmpty())
             lines.add(lineToAdd);
         if (endIndex < line.length())

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -89,7 +89,7 @@ public final class Constants {
     public static final String BEFORE_EACH_TOKEN_HYPHEN = "BEFORE-EACH";
     public static final String AFTER_EACH_TOKEN_HYPHEN = "AFTER-EACH";
     public static final String PARA_TOKEN = "PARA";
-    public static final List<String> IGNORED_TOKENS = Arrays.asList("END-CALL", "END-MOCK");
+    public static final List<String> IGNORED_TOKENS = Arrays.asList("END-CALL");
 
     // Configuration key values
     public static final String CONCATENATED_TEST_SUITES_CONFIG_KEY = "concatenated.test.suites";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -69,6 +69,7 @@ public final class Constants {
     public static final String LESS_THAN_EQUAL_TO_SIGN_KEYWORD = "<=";
     public static final String MOCK_KEYWORD = "MOCK";
     public static final String MOCK_TYPE = "mock-type";
+    public static final String QUALIFIED_FIELD_NAME = "qualified-field-name";
     public static final String ENDMOCK_KEYWORD = "END-MOCK";
     public static final String VERIFY_KEYWORD = "VERIFY";
     public static final String NEVER_HAPPENED_KEYWORD = "NEVER HAPPENED";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -82,6 +82,9 @@ public final class Constants {
     public static final String END_BEFORE_TOKEN = "END-BEFORE";
     public static final String AFTER_EACH_TOKEN = "AFTER EACH";
     public static final String END_AFTER_TOKEN = "END-AFTER";
+    public static final String IN_KEYWORD = "IN";
+    public static final String OF_KEYWORD = "OF";
+
     //BACKWARDS COMPATIBILITY TODO: remove values?
     public static final String BEFORE_EACH_TOKEN_HYPHEN = "BEFORE-EACH";
     public static final String AFTER_EACH_TOKEN_HYPHEN = "AFTER-EACH";

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/StringHelper.java
@@ -3,6 +3,7 @@ package org.openmainframeproject.cobolcheck.services;
 import org.openmainframeproject.cobolcheck.services.log.Log;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -213,6 +214,17 @@ public class StringHelper {
 
     public static boolean isStringContinuationLine(String line) {
         return line.startsWith("      -    '") || line.startsWith("      -    \"");
+    }
+
+    public static String moveToAreaB(String line){
+        return "           " + line.trim();
+    }
+
+    public static List<String> moveToAreaB(List<String> lines){
+        for (int i = 0; i < lines.size(); i++){
+            lines.set(i, moveToAreaB(lines.get(i)));
+        }
+        return lines;
     }
 
     /**

--- a/src/test/cobol/ALPHA/AlphaExpectationsTest.cut
+++ b/src/test/cobol/ALPHA/AlphaExpectationsTest.cut
@@ -35,22 +35,22 @@
            TestCase "Greater-than sign with an alphanumeric literal"
            move "Beta" to ws-field-1
            move "Alpha" to ws-field-2
-           Expect ws-field-1 > ws-field-2
+           Expect ws-field-1 > "Alpha"
 
            TestCase "Less-than sign with an alphanumeric literal"
            move "Beta" to ws-field-1
            move "Alpha" to ws-field-2
-           Expect ws-field-2 < ws-field-1
+           Expect ws-field-2 < "Beta"
 
            TestCase "Not greater-than sign with an alphanumeric literal"
            move "Beta" to ws-field-1
            move "Alpha" to ws-field-2
-           Expect ws-field-2 not > ws-field-1
+           Expect ws-field-2 not > "Beta"
 
            TestCase "Not less-than sign with an alphanumeric literal"
            move "Beta" to ws-field-1
            move "Alpha" to ws-field-2
-           Expect ws-field-1 not < ws-field-2
+           Expect ws-field-1 not < "Alpha"
 
            TestCase "Display numeric"
            move 6 to ws-display-numeric

--- a/src/test/cobol/FileCopy/FilecopyTests.cut
+++ b/src/test/cobol/FileCopy/FilecopyTests.cut
@@ -4,8 +4,8 @@
            Move "Alpha" TO IN-FIELD-1
            Move "Beta" TO IN-FIELD-2
            Perform 5200-PREPARE-OUTPUT-RECORD
-           Expect IN-FIELD-1 OF INPUT-RECORD TO EQUAL OUT-FIELD-1
-           Expect OUT-FIELD-2 OF OUTPUT-RECORD TO EQUAL IN-FIELD-2
+           Expect IN-FIELD-1 OF INPUT-RECORD TO EQUAL "Alpha"
+           Expect OUT-FIELD-2 OF OUTPUT-RECORD TO EQUAL "Beta"
 
 
 

--- a/src/test/cobol/MOCKTEST/MockCallTest.cut
+++ b/src/test/cobol/MOCKTEST/MockCallTest.cut
@@ -34,6 +34,16 @@
            VERIFY CALL VALUE-2 USING VALUE-1
                 HAPPENED ONCE
 
+           TestCase "Call mock with field and no arguments work"
+           MOCK CALL VALUE-2
+                MOVE "From mocked PROG2" TO VALUE-1
+           END-MOCK
+           PERFORM 700-MAKE-CALL
+           EXPECT VALUE-1 TO BE "From mocked PROG2"
+           EXPECT VALUE-2 TO BE "arg2"
+           VERIFY CALL VALUE-2
+                HAPPENED ONCE
+
       * Test for mocking call statements
       * Writing a comment to test stuff
       *

--- a/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
+++ b/src/test/cobol/MOCKTEST/MockSectionsAndParagraphsTest.cut
@@ -88,3 +88,27 @@
            END-MOCK
            PERFORM 400-CHANGE-2
            Expect VALUE-1 to be "Exit section is handled correctly"
+
+           TestCase "Mock one-liner with end mock on next line"
+           MOCK SECTION 400-CHANGE-2 MOVE "it works1" TO VALUE-1
+           END-MOCK
+           PERFORM 400-CHANGE-2
+           Expect VALUE-1 to be "it works1"
+
+           TestCase "Mock one-liner with content"
+           MOCK SECTION 400-CHANGE-2 MOVE "it works2" TO VALUE-1 END-MOCK
+           PERFORM 400-CHANGE-2
+           Expect VALUE-1 to be "it works2"
+
+           TestCase "Mock content with end-mock on the same line"
+           MOCK SECTION 400-CHANGE-2
+           MOVE "it works3" TO VALUE-1 END-MOCK
+           PERFORM 400-CHANGE-2
+           Expect VALUE-1 to be "it works3"
+
+           TestCase "Mock content on multiple lines, with end-mock on the same line as some content"
+           MOCK SECTION 400-CHANGE-2 MOVE "it works4" TO VALUE-1
+           MOVE "it works5" TO VALUE-2 END-MOCK
+           PERFORM 400-CHANGE-2
+           Expect VALUE-1 to be "it works4"
+           Expect VALUE-2 to be "it works5"

--- a/src/test/cobol/NUMBERS/SymbolicRelationsTest.cut
+++ b/src/test/cobol/NUMBERS/SymbolicRelationsTest.cut
@@ -38,43 +38,35 @@
 
            TestCase "Equal sign with ield compare"
            Move 25.74 to WS-FIELD-1
-           Move 25.74 to WS-FIELD-2
-           Expect WS-FIELD-1 = WS-FIELD-2
+           Expect WS-FIELD-1 = 25.74
 
            TestCase "Equal sign with field compare (should fail)"
            Move 25.74 to WS-FIELD-1
-           Move 25.75 to WS-FIELD-2
-           Expect WS-FIELD-1 = WS-FIELD-2
+           Expect WS-FIELD-1 = 25.75
 
            TestCase "Not equal sign with field compare"
            Move 25.74 to WS-FIELD-1
-           Move 25.75 to WS-FIELD-2
-           Expect WS-FIELD-1 not = WS-FIELD-2
+           Expect WS-FIELD-1 not = 25.75
 
            TestCase "Not equal sign with field compare (should fail)"
            Move 25.74 to WS-FIELD-1
-           Move 25.74 to WS-FIELD-2
-           Expect WS-FIELD-1 not = WS-FIELD-2
+           Expect WS-FIELD-1 not = 25.74
 
            TestCase "Not-equal sign with field compare"
            Move 25.74 to WS-FIELD-1
-           Move 25.75 to WS-FIELD-2
-           Expect WS-FIELD-1 != WS-FIELD-2
+           Expect WS-FIELD-1 != 25.75
 
            TestCase "Not-equal sign with field compare (should fail)"
            Move 25.74 to WS-FIELD-1
-           Move 25.74 to WS-FIELD-2
-           Expect WS-FIELD-1 != WS-FIELD-2
+           Expect WS-FIELD-1 != 25.74
 
            TestCase "Not not-equal sign with field compare"
            Move 25.74 to WS-FIELD-1
-           Move 25.74 to WS-FIELD-2
-           Expect WS-FIELD-1 NOT != WS-FIELD-2
+           Expect WS-FIELD-1 NOT != 25.74
 
            TestCase "Not not-equal sign with field compare (should fail)"
            Move 25.75 to WS-FIELD-1
-           Move 25.74 to WS-FIELD-2
-           Expect WS-FIELD-1 not != WS-FIELD-2
+           Expect WS-FIELD-1 not != 25.74
 
            TestCase "Less-than sign with literal compare"
            Move 18.067 to WS-FIELD-1
@@ -94,23 +86,19 @@
 
            TestCase "Less-than sign with field compare"
            Move 416.071 to WS-FIELD-1
-           Move 416.072 to WS-FIELD-2
-           Expect WS-FIELD-1 < WS-FIELD-2
+           Expect WS-FIELD-1 < 416.072
 
            TestCase "Less-than sign with field compare (should fail)"
            Move 416.072 to WS-FIELD-1
-           Move 416.072 to WS-FIELD-2
-           Expect WS-FIELD-1  < WS-FIELD-2
+           Expect WS-FIELD-1  < 416.072
 
            TestCase "Not less-than sign with field compare"
            Move 416.072 to WS-FIELD-1
-           Move 416.071 to WS-FIELD-2
-           Expect WS-FIELD-1 not < WS-FIELD-2
+           Expect WS-FIELD-1 not < 416.071
 
            TestCase "Not less-than sign with field compare (should fail)"
            Move 416.071 to WS-FIELD-1
-           Move 416.072 to WS-FIELD-2
-           Expect WS-FIELD-1 not < WS-FIELD-2
+           Expect WS-FIELD-1 not < 416.072
 
            TestCase "Greater-than sign with literal compare"
            Move 18.067 to WS-FIELD-1
@@ -122,33 +110,27 @@
 
            TestCase "Not greater-than sign with literal compare"
            move 107.701 to ws-field-1
-           move 107.701 to ws-field-2
-           expect ws-field-1 not > ws-field-2
+           expect ws-field-1 not > 107.701
 
            TestCase "Not greater-than sign with literal compare (should fail)"
            move 107.702 to ws-field-1
-           move 107.701 to ws-field-2
-           expect ws-field-1 not > ws-field-2
+           expect ws-field-1 not > 107.701
 
            TestCase "Greater-than sign with field compare"
            Move 1766.03145 to WS-FIELD-1
-           Move 1766.03144 to WS-FIELD-2
-           Expect WS-FIELD-1 > WS-FIELD-2
+           Expect WS-FIELD-1 > 1766.03144
 
            TestCase "Greater-than sign with field compare (should fail)"
            Move 1766.03143 to WS-FIELD-1
-           Move 1766.03144 to WS-FIELD-2
-           Expect WS-FIELD-1 > WS-FIELD-2
+           Expect WS-FIELD-1 > 1766.03144
 
            TestCase "Not greater-than sign with field to field compare"
            Move 1766.03144 to WS-FIELD-1
-           Move 1766.03144 to WS-FIELD-2
-           Expect WS-FIELD-1 Not > WS-FIELD-2
+           Expect WS-FIELD-1 Not > 1766.03144
 
            TestCase "Not greater-than sign with field compare (should fail)"
            Move 1766.03145 to WS-FIELD-1
-           Move 1766.03144 to WS-FIELD-2
-           Expect WS-FIELD-1 NOT > WS-FIELD-2
+           Expect WS-FIELD-1 NOT > 1766.03144
 
            TestCase "Greater-than-or-equal-to sign with literal compare when greater"
            Move 18.067 to WS-FIELD-1
@@ -176,63 +158,51 @@
 
            TestCase "Greater-than-or-equal-to-sign with field compare when equal"
            move 475.062 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 >= ws-field-2
+           expect ws-field-1 >= 475.062
 
            TestCase "Greater-than-or-equal-to-sign with field compare when greater"
            move 475.063 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 >= ws-field-2
+           expect ws-field-1 >= 475.062
 
            TestCase "Greater-than-or-equal-to-sign with field compare when less (should fail)"
            move 475.061 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 >= ws-field-2
+           expect ws-field-1 >= 475.062
 
            TestCase "Not greater-than-or-equal-to-sign with field compare when less"
            move 475.062 to ws-field-1
-           move 475.063 to ws-field-2
-           expect ws-field-1 not >= ws-field-2
+           expect ws-field-1 not >= 475.063
 
            TestCase "Not greater-than-or-equal-to-sign with field compare when equal (should fail)"
            move 475.062 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 not >= ws-field-2
+           expect ws-field-1 not >= 475.062
 
            TestCase "Not greater-than-or-equal-to-sign with field compare when greater (should fail)"
            move 475.063 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 not >= ws-field-2
+           expect ws-field-1 not >= 475.062
 
            TestCase "Less-than-or-equal-to-sign with field compare when equal"
            move 475.062 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 <= ws-field-2
+           expect ws-field-1 <= 475.062
 
            TestCase "Less-than-or-equal-to-sign with field compare when less"
            move 475.062 to ws-field-1
-           move 475.063 to ws-field-2
-           expect ws-field-1 <= ws-field-2
+           expect ws-field-1 <= 475.063
 
            TestCase "Less-than-or-equal-to-sign with field compare when greater (should fail)"
            move 475.063 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 <= ws-field-2
+           expect ws-field-1 <= 475.062
 
            TestCase "Not less-than-or-equal-to-sign with field compare when greater"
            move 475.063 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 not <= ws-field-2
+           expect ws-field-1 not <= 475.062
 
            TestCase "Not greater-than-or-equal-to-sign with field compare when equal (should fail)"
            move 475.062 to ws-field-1
-           move 475.062 to ws-field-2
-           expect ws-field-1 not <= ws-field-2
+           expect ws-field-1 not <= 475.062
 
            TestCase "Not greater-than-or-equal-to-sign with field compare when less (should fail)"
            move 475.062 to ws-field-1
-           move 475.063 to ws-field-2
-           expect ws-field-1 not <= ws-field-2
+           expect ws-field-1 not <= 475.063
 
            TestCase "Display Numeric field equals literal"
            move 123.45 to ws-display-field

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
@@ -47,14 +47,15 @@ public class KeywordsTest {
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.HAPPENED_KEYWORD,
                                 Constants.NEVER_HAPPENED_KEYWORD,
-                                Constants.USING_TOKEN,
                                 Constants.COBOL_TOKEN,
+                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
                                 Constants.BY_REFERENCE_TOKEN,
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
-                                Constants.PARENTHESIS_ENCLOSED_KEYWORD,
-                                Constants.ENDMOCK_KEYWORD),
+                                Constants.USING_TOKEN,
+                                Constants.IN_KEYWORD,
+                                Constants.OF_KEYWORD),
                         KeywordAction.FIELDNAME),
                 Arguments.of(Constants.NOT_KEYWORD, Constants.NOT_KEYWORD,
                         Arrays.asList(Constants.TO_BE_KEYWORD,
@@ -138,8 +139,13 @@ public class KeywordsTest {
                 Constants.AFTER_EACH_TOKEN_HYPHEN,
                 Constants.HAPPENED_KEYWORD,
                 Constants.NEVER_HAPPENED_KEYWORD,
-                Constants.USING_TOKEN,
-                Constants.ENDMOCK_KEYWORD), keyword.getValidNextKeys(null));
+                Constants.ENDMOCK_KEYWORD,
+                Constants.FIELDNAME_KEYWORD,
+                Constants.BY_REFERENCE_TOKEN,
+                Constants.BY_CONTENT_TOKEN,
+                Constants.BY_VALUE_TOKEN,
+                Constants.USING_TOKEN),
+            keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -176,7 +182,9 @@ public class KeywordsTest {
                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.TIME_KEYWORD,
-                Constants.TIMES_KEYWORD), keyword.getValidNextKeys(null));
+                Constants.TIMES_KEYWORD,
+                Constants.IN_KEYWORD,
+                Constants.OF_KEYWORD), keyword.getValidNextKeys(null));
     }
 
     @Test

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
@@ -36,17 +36,12 @@ public class KeywordsTest {
                         Arrays.asList(Constants.FIELDNAME_KEYWORD),
                         KeywordAction.ACTUAL_FIELDNAME),
                 Arguments.of(Constants.FIELDNAME_KEYWORD, Constants.FIELDNAME_KEYWORD,
-                        Arrays.asList(Constants.TO_BE_KEYWORD,
-                                Constants.NOT_KEYWORD,
-                                Constants.NOT_EQUAL_SIGN_KEYWORD,
-                                Constants.TO_EQUAL_KEYWORD,
+                        Arrays.asList(Constants.NOT_KEYWORD,
                                 Constants.EQUAL_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
-                                Constants.HAPPENED_KEYWORD,
-                                Constants.NEVER_HAPPENED_KEYWORD,
                                 Constants.COBOL_TOKEN,
                                 Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                                 Constants.FIELDNAME_KEYWORD,
@@ -54,25 +49,17 @@ public class KeywordsTest {
                                 Constants.BY_CONTENT_TOKEN,
                                 Constants.BY_VALUE_TOKEN,
                                 Constants.USING_TOKEN,
-                                Constants.IN_KEYWORD,
-                                Constants.OF_KEYWORD),
+                                Constants.QUALIFIED_FIELD_NAME),
                         KeywordAction.FIELDNAME),
                 Arguments.of(Constants.NOT_KEYWORD, Constants.NOT_KEYWORD,
-                        Arrays.asList(Constants.TO_BE_KEYWORD,
-                                Constants.TO_EQUAL_KEYWORD,
-                                Constants.EQUAL_SIGN_KEYWORD,
-                                Constants.NOT_EQUAL_SIGN_KEYWORD,
+                        Arrays.asList(Constants.EQUAL_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_SIGN_KEYWORD,
                                 Constants.LESS_THAN_SIGN_KEYWORD,
                                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD),
                         KeywordAction.REVERSE_LOGIC),
                 Arguments.of(Constants.TO_BE_KEYWORD, Constants.TO_BE_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD,
-                                Constants.COBOL_TOKEN,
-                                Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                                Constants.NUMERIC_LITERAL_KEYWORD,
-                                Constants.BOOLEAN_VALUE),
+                        Arrays.asList(),
                         KeywordAction.EXPECTED_VALUE),
                 Arguments.of(Constants.TESTSUITE_KEYWORD, Constants.TESTSUITE_KEYWORD,
                         Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD),
@@ -85,11 +72,7 @@ public class KeywordsTest {
                                 Constants.BOOLEAN_VALUE),
                         KeywordAction.EXPECTED_VALUE),
                 Arguments.of(Constants.NOT_EQUAL_SIGN_KEYWORD, Constants.NOT_EQUAL_SIGN_KEYWORD,
-                        Arrays.asList(Constants.FIELDNAME_KEYWORD,
-                                Constants.COBOL_TOKEN,
-                                Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                                Constants.NUMERIC_LITERAL_KEYWORD,
-                                Constants.BOOLEAN_VALUE),
+                        Arrays.asList(),
                         KeywordAction.REVERSE_LOGIC),
                 Arguments.of(Constants.GREATER_THAN_SIGN_KEYWORD, Constants.GREATER_THAN_SIGN_KEYWORD,
                         Arrays.asList(Constants.FIELDNAME_KEYWORD,
@@ -127,24 +110,21 @@ public class KeywordsTest {
         assertEquals(Constants.ALPHANUMERIC_LITERAL_KEYWORD, keyword.value());
         assertEquals(KeywordAction.FIELDNAME, keyword.keywordAction());
         assertEquals(Arrays.asList(Constants.ALPHANUMERIC_LITERAL_KEYWORD,
-                Constants.EXPECT_KEYWORD,
-                Constants.COBOL_TOKEN,
-                Constants.TESTSUITE_KEYWORD,
-                Constants.TESTCASE_KEYWORD,
-                Constants.MOCK_KEYWORD,
-                Constants.VERIFY_KEYWORD,
-                Constants.BEFORE_EACH_TOKEN,
-                Constants.BEFORE_EACH_TOKEN_HYPHEN,
-                Constants.AFTER_EACH_TOKEN,
-                Constants.AFTER_EACH_TOKEN_HYPHEN,
-                Constants.HAPPENED_KEYWORD,
-                Constants.NEVER_HAPPENED_KEYWORD,
-                Constants.ENDMOCK_KEYWORD,
-                Constants.FIELDNAME_KEYWORD,
-                Constants.BY_REFERENCE_TOKEN,
-                Constants.BY_CONTENT_TOKEN,
-                Constants.BY_VALUE_TOKEN,
-                Constants.USING_TOKEN),
+                        Constants.EXPECT_KEYWORD,
+                        Constants.COBOL_TOKEN,
+                        Constants.TESTSUITE_KEYWORD,
+                        Constants.TESTCASE_KEYWORD,
+                        Constants.MOCK_KEYWORD,
+                        Constants.VERIFY_KEYWORD,
+                        Constants.BEFORE_EACH_TOKEN,
+                        Constants.BEFORE_EACH_TOKEN_HYPHEN,
+                        Constants.AFTER_EACH_TOKEN,
+                        Constants.AFTER_EACH_TOKEN_HYPHEN,
+                        Constants.FIELDNAME_KEYWORD,
+                        Constants.BY_REFERENCE_TOKEN,
+                        Constants.BY_CONTENT_TOKEN,
+                        Constants.BY_VALUE_TOKEN,
+                        Constants.USING_TOKEN),
             keyword.getValidNextKeys(null));
     }
 
@@ -154,7 +134,7 @@ public class KeywordsTest {
         assertEquals(Constants.NUMERIC_LITERAL_KEYWORD, keyword.value());
         assertEquals(KeywordAction.FIELDNAME, keyword.keywordAction());
         assertEquals(Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN, Constants.TESTSUITE_KEYWORD,
-                Constants.TESTCASE_KEYWORD, Constants.MOCK_KEYWORD, Constants.VERIFY_KEYWORD, Constants.TIME_KEYWORD,
+                Constants.TESTCASE_KEYWORD, Constants.MOCK_KEYWORD, Constants.VERIFY_KEYWORD,
                         Constants.TIMES_KEYWORD), keyword.getValidNextKeys(null));
     }
 
@@ -172,7 +152,6 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
-                Constants.ENDMOCK_KEYWORD,
                 Constants.VERIFY_KEYWORD,
                 Constants.PARENTHESIS_ENCLOSED_KEYWORD,
                 Constants.GREATER_THAN_SIGN_KEYWORD,
@@ -183,8 +162,7 @@ public class KeywordsTest {
                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.TIME_KEYWORD,
                 Constants.TIMES_KEYWORD,
-                Constants.IN_KEYWORD,
-                Constants.OF_KEYWORD), keyword.getValidNextKeys(null));
+                Constants.QUALIFIED_FIELD_NAME), keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -211,6 +189,70 @@ public class KeywordsTest {
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
                 Constants.VERIFY_KEYWORD), keyword.getValidNextKeys(null));
+    }
+
+    @Test
+    public void when_the_token_is_IN_it_is_treated_as_a_qualified_field_name() {
+        Keyword keyword = Keywords.getKeywordFor("IN", false);
+        assertEquals(Constants.QUALIFIED_FIELD_NAME, keyword.value());
+        assertEquals(KeywordAction.NONE, keyword.keywordAction());
+        assertEquals(Arrays.asList(Constants.COBOL_TOKEN, Constants.FIELDNAME_KEYWORD),
+                keyword.getValidNextKeys(null));
+    }
+
+    @Test
+    public void when_the_token_is_OF_it_is_treated_as_a_qualified_field_name() {
+        Keyword keyword = Keywords.getKeywordFor("OF", false);
+        assertEquals(Constants.QUALIFIED_FIELD_NAME, keyword.value());
+        assertEquals(KeywordAction.NONE, keyword.keywordAction());
+        assertEquals(Arrays.asList(Constants.COBOL_TOKEN, Constants.FIELDNAME_KEYWORD),
+                keyword.getValidNextKeys(null));
+    }
+
+    @Test
+    public void it_gets_valid_next_keys_in_mock_context_for_field_name() {
+        Keyword keyword = Keywords.getKeywordFor("100-DO-WORK", true);
+        assertEquals(Arrays.asList(Constants.ENDMOCK_KEYWORD,
+                        Constants.FIELDNAME_KEYWORD,
+                        Constants.BY_REFERENCE_TOKEN,
+                        Constants.BY_CONTENT_TOKEN,
+                        Constants.BY_VALUE_TOKEN,
+                        Constants.USING_TOKEN),
+                keyword.getValidNextKeys(Constants.MOCK_KEYWORD));
+    }
+
+    @Test
+    public void it_gets_valid_next_keys_in_verify_context_for_field_name() {
+        Keyword keyword = Keywords.getKeywordFor("100-DO-WORK", true);
+        assertEquals(Arrays.asList(Constants.FIELDNAME_KEYWORD,
+                        Constants.BY_REFERENCE_TOKEN,
+                        Constants.BY_CONTENT_TOKEN,
+                        Constants.BY_VALUE_TOKEN,
+                        Constants.USING_TOKEN,
+                        Constants.HAPPENED_KEYWORD,
+                        Constants.NEVER_HAPPENED_KEYWORD),
+                keyword.getValidNextKeys(Constants.VERIFY_KEYWORD));
+    }
+
+    @Test
+    public void it_gets_valid_next_keys_in_expect_context_for_field_name() {
+        Keyword keyword = Keywords.getKeywordFor("100-DO-WORK", true);
+        assertEquals(Arrays.asList(Constants.TO_BE_KEYWORD,
+                        Constants.EQUAL_SIGN_KEYWORD,
+                        Constants.TO_EQUAL_KEYWORD,
+                        Constants.NOT_KEYWORD,
+                        Constants.LESS_THAN_SIGN_KEYWORD,
+                        Constants.NOT_EQUAL_SIGN_KEYWORD,
+                        Constants.LESS_THAN_SIGN_KEYWORD,
+                        Constants.EQUAL_SIGN_KEYWORD,
+                        Constants.GREATER_THAN_SIGN_KEYWORD,
+                        Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
+                        Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
+                        Constants.ALPHANUMERIC_LITERAL_KEYWORD,
+                        Constants.FIELDNAME_KEYWORD,
+                        Constants.QUALIFIED_FIELD_NAME,
+                        Constants.PARENTHESIS_ENCLOSED_KEYWORD),
+                keyword.getValidNextKeys(Constants.EXPECT_KEYWORD));
     }
 
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
@@ -27,7 +27,7 @@ public class KeywordsTest {
         Keyword keyword = Keywords.getKeywordFor(key, false);
         assertEquals(expectedKeywordValue, keyword.value());
         assertEquals(expectedKeywordAction, keyword.keywordAction());
-        assertEquals(expectedValidNextKey, keyword.getvalidNextKeys());
+        assertEquals(expectedValidNextKey, keyword.getvalidNextKeys(null));
     }
 
     private static Stream<Arguments> KeywordProvider() {
@@ -139,7 +139,7 @@ public class KeywordsTest {
                 Constants.HAPPENED_KEYWORD,
                 Constants.NEVER_HAPPENED_KEYWORD,
                 Constants.USING_TOKEN,
-                Constants.ENDMOCK_KEYWORD), keyword.getvalidNextKeys());
+                Constants.ENDMOCK_KEYWORD), keyword.getvalidNextKeys(null));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class KeywordsTest {
         assertEquals(KeywordAction.FIELDNAME, keyword.keywordAction());
         assertEquals(Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN, Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD, Constants.MOCK_KEYWORD, Constants.VERIFY_KEYWORD, Constants.TIME_KEYWORD,
-                        Constants.TIMES_KEYWORD), keyword.getvalidNextKeys());
+                        Constants.TIMES_KEYWORD), keyword.getvalidNextKeys(null));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class KeywordsTest {
                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.TIME_KEYWORD,
-                Constants.TIMES_KEYWORD), keyword.getvalidNextKeys());
+                Constants.TIMES_KEYWORD), keyword.getvalidNextKeys(null));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
-                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys());
+                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys(null));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
-                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys());
+                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys(null));
     }
 
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordsTest.java
@@ -27,7 +27,7 @@ public class KeywordsTest {
         Keyword keyword = Keywords.getKeywordFor(key, false);
         assertEquals(expectedKeywordValue, keyword.value());
         assertEquals(expectedKeywordAction, keyword.keywordAction());
-        assertEquals(expectedValidNextKey, keyword.getvalidNextKeys(null));
+        assertEquals(expectedValidNextKey, keyword.getValidNextKeys(null));
     }
 
     private static Stream<Arguments> KeywordProvider() {
@@ -139,7 +139,7 @@ public class KeywordsTest {
                 Constants.HAPPENED_KEYWORD,
                 Constants.NEVER_HAPPENED_KEYWORD,
                 Constants.USING_TOKEN,
-                Constants.ENDMOCK_KEYWORD), keyword.getvalidNextKeys(null));
+                Constants.ENDMOCK_KEYWORD), keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -149,7 +149,7 @@ public class KeywordsTest {
         assertEquals(KeywordAction.FIELDNAME, keyword.keywordAction());
         assertEquals(Arrays.asList(Constants.EXPECT_KEYWORD, Constants.COBOL_TOKEN, Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD, Constants.MOCK_KEYWORD, Constants.VERIFY_KEYWORD, Constants.TIME_KEYWORD,
-                        Constants.TIMES_KEYWORD), keyword.getvalidNextKeys(null));
+                        Constants.TIMES_KEYWORD), keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class KeywordsTest {
                 Constants.GREATER_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.LESS_THAN_EQUAL_TO_SIGN_KEYWORD,
                 Constants.TIME_KEYWORD,
-                Constants.TIMES_KEYWORD), keyword.getvalidNextKeys(null));
+                Constants.TIMES_KEYWORD), keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
-                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys(null));
+                Constants.VERIFY_KEYWORD), keyword.getValidNextKeys(null));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class KeywordsTest {
                 Constants.TESTSUITE_KEYWORD,
                 Constants.TESTCASE_KEYWORD,
                 Constants.MOCK_KEYWORD,
-                Constants.VERIFY_KEYWORD), keyword.getvalidNextKeys(null));
+                Constants.VERIFY_KEYWORD), keyword.getValidNextKeys(null));
     }
 
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockIT.java
@@ -406,7 +406,7 @@ public class MockIT {
             "      *In testcase: \"Local mock overwrites global mock\"                         " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "           ADD 1 TO UT-1-1-1-MOCK-COUNT                                         " + Constants.NEWLINE +
-            "                MOVE \"This is\" TO VALUE-1                                       " + Constants.NEWLINE +
+            "           MOVE \"This is\" TO VALUE-1                                            " + Constants.NEWLINE +
             "           .                                                                    " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
             "       UT-1-2-1-MOCK.                                                              " + Constants.NEWLINE +
@@ -624,7 +624,7 @@ public class MockIT {
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "           ADD 1 TO UT-1-0-1-MOCK-COUNT                                         " + Constants.NEWLINE +
-            "               MOVE \"mock\" TO VALUE-1                                           " + Constants.NEWLINE +
+            "           MOVE \"mock\" TO VALUE-1                                               " + Constants.NEWLINE +
             "           .                                                                    " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
             "       UT-1-0-2-MOCK.                                                              " + Constants.NEWLINE +
@@ -634,7 +634,7 @@ public class MockIT {
             "      *In testsuite: \"Mocking tests\"                                            " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "           ADD 1 TO UT-1-0-2-MOCK-COUNT                                         " + Constants.NEWLINE +
-            "               MOVE \"prog2\" TO VALUE-1                                          " + Constants.NEWLINE +
+            "           MOVE \"prog2\" TO VALUE-1                                              " + Constants.NEWLINE +
             "           .                                                                    " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
             "       UT-1-1-1-MOCK.                                                              " + Constants.NEWLINE +
@@ -644,7 +644,7 @@ public class MockIT {
             "      *In testcase: \"Local mock overwrites global mock\"                         " + Constants.NEWLINE +
             "      *****************************************************************         " + Constants.NEWLINE +
             "           ADD 1 TO UT-1-1-1-MOCK-COUNT                                         " + Constants.NEWLINE +
-            "                MOVE \"Goodbye\" TO VALUE-1                                       " + Constants.NEWLINE +
+            "           MOVE \"Goodbye\" TO VALUE-1                                           " + Constants.NEWLINE +
             "           .                                                                    " + Constants.NEWLINE +
             "                                                                                " + Constants.NEWLINE +
             "       UT-1-2-1-MOCK.                                                              " + Constants.NEWLINE +

--- a/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/MockingTest.java
@@ -200,8 +200,8 @@ public class MockingTest {
         String str6 = "       END-MOCK";
 
         List<String> expected = new ArrayList<>();
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
@@ -219,8 +219,8 @@ public class MockingTest {
         String str6 = "       END-MOCK";
 
         List<String> expected = new ArrayList<>();
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
@@ -238,8 +238,8 @@ public class MockingTest {
         String str6 = "       END-MOCK";
 
         List<String> expected = new ArrayList<>();
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, null);
 
@@ -258,9 +258,9 @@ public class MockingTest {
         String str7 = "       END-MOCK";
 
         List<String> expected = new ArrayList<>();
-        expected.add("          ");
-        expected.add(str5);
-        expected.add(str6);
+        expected.add("           ");
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
 
         Mockito.when(mockedReader.readLine()).thenReturn(str1, str2, str3, str4, str5, str6, str7, null);
 
@@ -338,8 +338,8 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("       UT-1-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
 
@@ -423,8 +423,8 @@ public class MockingTest {
         expected.add("      *In testcase: \"Name of test case\"");
         expected.add("      *****************************************************************");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
 
@@ -458,8 +458,8 @@ public class MockingTest {
         expected.add("      *In testcase: \"Name of test case\"");
         expected.add("      *****************************************************************");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
 
@@ -493,8 +493,8 @@ public class MockingTest {
         expected.add("      *In testcase: \"Name of test case\"");
         expected.add("      *****************************************************************");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
 
@@ -529,8 +529,8 @@ public class MockingTest {
         expected.add("      *In testcase: \"Name of test case\"");
         expected.add("      *****************************************************************");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
 
@@ -574,26 +574,26 @@ public class MockingTest {
         expected.add("      *****************************************************************");
         expected.add("       UT-1-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-1-MOCK-COUNT");
-        expected.add(str4);
-        expected.add(str5);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
         expected.add("       UT-1-1-2-MOCK.");
         expected.add("           ADD 1 TO UT-1-1-2-MOCK-COUNT");
-        expected.add(str8);
-        expected.add(str9);
+        expected.add("           MOVE \"hey\" TO greeting");
+        expected.add("           MOVE \"bye\" TO greeting2");
         expected.add("           .");
         expected.add("");
         expected.add("       UT-1-2-1-MOCK.");
         expected.add("           ADD 1 TO UT-1-2-1-MOCK-COUNT");
-        expected.add(str13);
-        expected.add(str14);
+        expected.add("           ADD 1 TO WS-COUNT");
+        expected.add("           MOVE \"something else\" TO other");
         expected.add("           .");
         expected.add("");
         expected.add("       UT-2-1-1-MOCK.");
         expected.add("           ADD 1 TO UT-2-1-1-MOCK-COUNT");
-        expected.add(str19);
-        expected.add(str20);
+        expected.add("           MOVE \"something\" TO this");
+        expected.add("           ADD 1 TO WS-COUNT");
         expected.add("           .");
         expected.add("");
 

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
@@ -325,7 +325,7 @@ public class TestSuiteErrorLogTest {
         expectedResult += "Unexpected token on line 3, index 24:" + Constants.NEWLINE;
         expectedResult += "Following <WS-HELLO> classified as <fieldname>" + Constants.NEWLINE;
         expectedResult += "Expected classification in the context of EXPECT: [TO BE, =, TO EQUAL, NOT, <, !=, <, =, >, " +
-                ">=, <=, alphanumeric-literal, fieldname, IN, OF, parenthesis-enclosed]" + Constants.NEWLINE;
+                ">=, <=, alphanumeric-literal, fieldname, qualified-field-name, parenthesis-enclosed]" + Constants.NEWLINE;
         expectedResult += "Got <HAPPENED> classified as <HAPPENED>" + Constants.NEWLINE + Constants.NEWLINE;
         expectedResult += "SYNTAX ERROR in file: null:3:33:" + Constants.NEWLINE;
         expectedResult += "Unexpected token on line 3, index 33:" + Constants.NEWLINE;

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
@@ -236,4 +236,149 @@ public class TestSuiteErrorLogTest {
         String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
+
+    @Test
+    public void it_catches_unexpected_keyword_in_a_mock_context() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       MOCK SECTION 2 100-HELLO END-MOCK"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:3:21:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 21:" + Constants.NEWLINE;
+        expectedResult += "Following <SECTION> classified as <mock-type>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of MOCK: [fieldname, alphanumeric-literal]" + Constants.NEWLINE;
+        expectedResult += "Got <    2> classified as <numeric-literal>" + Constants.NEWLINE + Constants.NEWLINE;
+        expectedResult += "SYNTAX ERROR in file: null:3:23:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 23:" + Constants.NEWLINE;
+        expectedResult += "Following <2> classified as <numeric-literal>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of MOCK:   []" + Constants.NEWLINE;
+        expectedResult += "Got <100-HELLO> classified as <fieldname>" + Constants.NEWLINE + Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_at_the_end_of_mock_context() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       MOCK SECTION 100-HELLO HAPPENED END-MOCK"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:2:13:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 2, index 13:" + Constants.NEWLINE;
+        expectedResult += "Cannot have Cobol Check keyword <HAPPENED> inside a MOCK block" + Constants.NEWLINE+ Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_at_the_end_of_mock_context_with_arguments() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       MOCK CALL 'value' USING BY CONTENT VALUE-1, VALUE-2 ONCE END-MOCK"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:2:58:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 2, index 58:" + Constants.NEWLINE;
+        expectedResult += "Cannot have Cobol Check keyword <ONCE> inside a MOCK block" + Constants.NEWLINE+ Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_in_an_expect_context() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       EXPECT WS-HELLO HAPPENED ONCE"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:3:21:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 21:" + Constants.NEWLINE;
+        expectedResult += "Following <WS-HELLO> classified as <fieldname>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of EXPECT: [TO BE, and so on...]" + Constants.NEWLINE;
+        expectedResult += "Got <HAPPENED> classified as <HAPPENED>" + Constants.NEWLINE + Constants.NEWLINE;
+        expectedResult += "SYNTAX ERROR in file: null:3:23:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 23:" + Constants.NEWLINE;
+        expectedResult += "Following <HAPPENED> classified as <HAPPENED>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of EXPECT:   []" + Constants.NEWLINE;
+        expectedResult += "Got <ONCE> classified as <ONCE>" + Constants.NEWLINE + Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_in_a_verify_context() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       VERIFY CALL MOVE 'PROG3' HAPPENED ONCE"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:3:21:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 21:" + Constants.NEWLINE;
+        expectedResult += "Following <CALL> classified as <mock-type>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of VERIFY: [field-name, alphanumeric-literal]" + Constants.NEWLINE;
+        expectedResult += "Got <MOVE> classified as <cobol-token>" + Constants.NEWLINE + Constants.NEWLINE;
+        expectedResult += "SYNTAX ERROR in file: null:3:23:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 23:" + Constants.NEWLINE;
+        expectedResult += "Following <MOVE> classified as <cobol-token>" + Constants.NEWLINE;
+        expectedResult += "Expected classification in the context of VERIFY:   []" + Constants.NEWLINE;
+        expectedResult += "Got <'PROG3'> classified as <alphanumeric-literal>" + Constants.NEWLINE + Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void it_catches_unexpected_keyword_after_verify() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("       VERIFY CALL 'PROG3' HAPPENED ONCE"+ Constants.NEWLINE);
+        testSuite.append("       BEFORE EACH"+ Constants.NEWLINE);
+
+        String expectedResult = "";
+        expectedResult += "SYNTAX ERROR in file: null:4:7:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 4, index 7:" + Constants.NEWLINE;
+        expectedResult += "Following <ONCE> classified as <ONCE>" + Constants.NEWLINE;
+        expectedResult += "Expected classification: [cobol-token, TESTSUITE, TESTCASE, MOCK, VERIFY, EXPECT]" + Constants.NEWLINE;
+        expectedResult += "Got <BEFORE EACH> classified as <BEFORE EACH>" + Constants.NEWLINE + Constants.NEWLINE;
+
+        assertThrows(TestSuiteSyntaxException.class, () -> {
+            testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
+                    numericFields);
+        });
+
+        String actualResult = testSuiteErrorLog.getErrorMessages();
+        assertEquals(expectedResult, actualResult);
+    }
+
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
@@ -71,6 +71,24 @@ public class TestSuiteErrorLogTest {
     }
 
     @Test
+    public void it_ends__mock_context_after_call_mock_with_no_arguments() {
+        testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
+        testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);
+        testSuite.append("           MOCK CALL 'PROG1'"+ Constants.NEWLINE);
+        testSuite.append("                MOVE \"From mocked PROG1\" TO VALUE-1"+ Constants.NEWLINE);
+        testSuite.append("           END-MOCK"+ Constants.NEWLINE);
+        testSuite.append("           PERFORM 600-MAKE-CALL"+ Constants.NEWLINE);
+        testSuite.append("           EXPECT VALUE-1 TO BE \"From mocked PROG1\""+ Constants.NEWLINE);
+
+        String expectedResult = null;
+
+        testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
+
+        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
     public void it_catches_unexpected_keyword_inside_mock_block() {
         testSuite.append("       TESTSUITE \"Name of test suite\""+ Constants.NEWLINE);
         testSuite.append("       TESTCASE \"Name of test case\""+ Constants.NEWLINE);

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteErrorLogTest.java
@@ -66,7 +66,7 @@ public class TestSuiteErrorLogTest {
                     numericFields);
         });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -80,11 +80,11 @@ public class TestSuiteErrorLogTest {
         testSuite.append("           PERFORM 600-MAKE-CALL"+ Constants.NEWLINE);
         testSuite.append("           EXPECT VALUE-1 TO BE \"From mocked PROG1\""+ Constants.NEWLINE);
 
-        String expectedResult = null;
+        String expectedResult = "";
 
         testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -106,7 +106,7 @@ public class TestSuiteErrorLogTest {
                     numericFields);
         });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -122,13 +122,16 @@ public class TestSuiteErrorLogTest {
         expectedResult += "SYNTAX ERROR in file: null:4:8:" + Constants.NEWLINE;
         expectedResult += "Unexpected token on line 4, index  8:" + Constants.NEWLINE;
         expectedResult += "Cannot have Cobol Check keyword <VERIFY> inside a BEFORE EACH block" + Constants.NEWLINE + Constants.NEWLINE;
+        expectedResult += "SYNTAX ERROR in file: null:3:33:" + Constants.NEWLINE;
+        expectedResult += "Unexpected token on line 3, index 33:" + Constants.NEWLINE;
+        expectedResult += "Cannot have Cobol Check keyword <HAPPENED> inside a BEFORE EACH block" + Constants.NEWLINE + Constants.NEWLINE;
 
         assertThrows(TestSuiteSyntaxException.class, () -> {
             testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())),
                     numericFields);
         });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -153,7 +156,7 @@ public class TestSuiteErrorLogTest {
                     numericFields);
         });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -177,7 +180,7 @@ public class TestSuiteErrorLogTest {
                     numericFields);
         });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -197,7 +200,7 @@ public class TestSuiteErrorLogTest {
                             numericFields);
                 });
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -213,11 +216,11 @@ public class TestSuiteErrorLogTest {
         testSuite.append("           MOVE 0 TO BANKNR IN AARM503-PARM"+ Constants.NEWLINE);
         testSuite.append("           END-BEFORE"+ Constants.NEWLINE);
 
-        String expectedResult = null;
+        String expectedResult = "";
 
         testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 
@@ -226,11 +229,11 @@ public class TestSuiteErrorLogTest {
         testSuite.append("           TESTSUITE 'TEST'"+ Constants.NEWLINE);
         testSuite.append("           MOCK SECTION 000-START END-MOCK"+ Constants.NEWLINE);
 
-        String expectedResult = null;
+        String expectedResult = "";
 
         testSuiteParser.getParsedTestSuiteLines(new BufferedReader(new StringReader(testSuite.toString())), numericFields);
 
-        String actualResult = testSuiteErrorLog.getLastErrorMessage();
+        String actualResult = testSuiteErrorLog.getErrorMessages();
         assertEquals(expectedResult, actualResult);
     }
 }

--- a/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserCodeInsertionTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/TestSuiteParserCodeInsertionTest.java
@@ -116,7 +116,7 @@ public class TestSuiteParserCodeInsertionTest {
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-MESSAGE TO UT-ACTUAL                                         ");
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
-        ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-TEXT                                                         ");
+        ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE \"Message\"                                                         ");
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("               TO UT-EXPECTED                                                   ");
         ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
@@ -131,7 +131,7 @@ public class TestSuiteParserCodeInsertionTest {
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-MESSAGE TO UT-ACTUAL                                         ");
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
-        ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-TEXT                                                         ");
+        ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE \"Message\"                                                         ");
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("               TO UT-EXPECTED                                                   ");
         ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
@@ -198,7 +198,7 @@ public class TestSuiteParserCodeInsertionTest {
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-ACTUAL TO UT-ACTUAL-NUMERIC                                  ");
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
-        NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-EXPECTED TO UT-EXPECTED-NUMERIC                              ");
+        NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           MOVE 42 TO UT-EXPECTED-NUMERIC                              ");
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append("           SET UT-RELATION-EQ TO TRUE                                           ");
         NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
@@ -211,7 +211,7 @@ public class TestSuiteParserCodeInsertionTest {
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-ACTUAL TO UT-ACTUAL-NUMERIC                                  ");
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
-        NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE WS-EXPECTED TO UT-EXPECTED-NUMERIC                              ");
+        NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           MOVE 42 TO UT-EXPECTED-NUMERIC                              ");
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append("           SET UT-RELATION-EQ TO TRUE                                           ");
         NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.append(Constants.NEWLINE);
@@ -362,19 +362,19 @@ public class TestSuiteParserCodeInsertionTest {
                              "WS-MESSAGE", null, ALPHANUMERIC_LITERAL_NON_EQUALITY_EXPECTED_RESULT.toString()),
                 Arguments.of("           EXPECT WS-MESSAGE != \"Hello\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_LITERAL_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE TO BE WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE TO BE \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE TO EQUAL WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE TO EQUAL \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE = WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE = \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE NOT TO BE WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE NOT TO BE \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE NOT TO EQUAL WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE NOT TO EQUAL \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE NOT = WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE NOT = \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-MESSAGE != WS-TEXT",
+                Arguments.of("           EXPECT WS-MESSAGE != \"Message\"",
                              "WS-MESSAGE", null, ALPHANUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
                 Arguments.of("           EXPECT WS-VALUE TO BE 18.92",
                              "WS-VALUE", DataType.FLOATING_POINT,
@@ -403,25 +403,25 @@ public class TestSuiteParserCodeInsertionTest {
                 Arguments.of("           EXPECT WS-ACTUAL > 18.004",
                              "WS-ACTUAL", DataType.FLOATING_POINT,
                                                  NUMERIC_LITERAL_GREATER_THAN_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL TO BE WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL TO BE 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL TO EQUAL WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL TO EQUAL 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL = WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL = 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL NOT TO BE WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL NOT TO BE 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL NOT TO EQUAL WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL NOT TO EQUAL 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL NOT = WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL NOT = 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString()),
-                Arguments.of("           EXPECT WS-ACTUAL != WS-EXPECTED",
+                Arguments.of("           EXPECT WS-ACTUAL != 42",
                              "WS-ACTUAL", DataType.PACKED_DECIMAL,
                                                  NUMERIC_FIELD_NON_EQUALITY_EXPECTED_RESULT.toString())
         );


### PR DESCRIPTION
Syntax check for cut-files has become more robust. It now validates the order of recognized keywords in regard to a context. This could be a MOCK-, EXPECT- or VERIFY context.