### PR TITLE
Bugfix set configuration

### DIFF
--- a/vs code extension/CHANGELOG.md
+++ b/vs code extension/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 All notable changes to the "cobol-unit-test" extension will be documented in this file. Versioning according to SemVer: https://semver.org/ 
+## [0.3.9] 02.01.2023
+- Bugfix: Fixed an issue where the configure-command would remove a line from the configuration file, everytime you would overwrite an existing value.
+
 ## [0.3.8] 21.12.2022
 - Fix for last release
 

--- a/vs code extension/client/package.json
+++ b/vs code extension/client/package.json
@@ -3,7 +3,7 @@
 	"description": "Cobol-check extension to run cobol unit tests",
 	"author": "Open Mainframe Project",
 	"license": "MIT",
-	"version": "0.3.3",
+	"version": "0.3.2",
 	"publisher": "openmainframeproject",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vs code extension/client/package.json
+++ b/vs code extension/client/package.json
@@ -3,7 +3,7 @@
 	"description": "Cobol-check extension to run cobol unit tests",
 	"author": "Open Mainframe Project",
 	"license": "MIT",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"publisher": "openmainframeproject",
 	"engines": {
 		"vscode": "^1.52.0"

--- a/vs code extension/client/src/services/CobolCheckConfiguration.ts
+++ b/vs code extension/client/src/services/CobolCheckConfiguration.ts
@@ -52,7 +52,7 @@ export function setConfiguration(configurationPath : string, key : string, newVa
 
 			let keyValue = trimmedLine.split('=');
 			if (keyValue.length > 1 && keyValue[0].trim() === key){
-				newConfigurationText += key + ' = ' + newValue;
+				newConfigurationText += key + ' = ' + newValue + '\n';
 				keyHasBeenFound = true;
 				LOGGER.log("Updated configuration key: " + key + " with value: " + newValue, LOGGER.INFO);
 			} else{

--- a/vs code extension/package.json
+++ b/vs code extension/package.json
@@ -8,7 +8,7 @@
         "Snippets"
     ],
     "description": "Extension for running unit tests in Cobol",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "icon": "images/cobol-check-logo-small.png",
     "engines": {
         "vscode": "^1.46.0"


### PR DESCRIPTION
Fixed an issue where using the "configure"-extension command would remove a line underneath the line of the key you wanted to set