### PR TITLE
use parentheses as token seperator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,3 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
-
-/zapp.json
-.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
+
+/zapp.json
+.gitignore

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/neopragma/cobol-check.svg?branch=main)](https://travis-ci.com/neopragma/cobol-check) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=neopragma_cobol-check&metric=alert_status)](https://sonarcloud.io/dashboard?id=neopragma_cobol-check)
 
 Cobol Check provides fine-grained unit testing/checking for Cobol at the same conceptual level of detail as unit testing frameworks for other languages, such as Python, Ruby, C#, and Java. 
-
+ 
 ## Feature overview
 - Fine-grained assertions
 - Stubs and mocks

--- a/src/test/java/org/openmainframeproject/cobolcheck/KeywordExtractorTest.java
+++ b/src/test/java/org/openmainframeproject/cobolcheck/KeywordExtractorTest.java
@@ -52,6 +52,15 @@ public class KeywordExtractorTest {
         assertEquals("TO BE", tokens.get(3));
         assertEquals(4, tokens.size());
     }
+    @Test
+
+    public void parentheses_acts_as_seperator() {
+        tokens = extractor.extractTokensFrom("VARIABLE(IDX) (START:LENGTH)");
+        assertEquals("VARIABLE", tokens.get(0));
+        assertEquals("(IDX)", tokens.get(1));
+        assertEquals("(START:LENGTH)", tokens.get(2));
+        assertEquals(3, tokens.size());
+    }
 
     @Test
     public void given_the_first_word_in_a_two_word_keyword_and_the_second_token_matches_the_expected_second_word_it_knows_it_is_not_a_match() {


### PR DESCRIPTION
This will enable COBOL check to e,g. correctly parse:
EXPECT VARIBLE-IN-TABLE(TALLY) TO BE NUMERIC 2
just like 
EXPECT VARIBLE-IN-TABLE (TALLY) TO BE NUMERIC 2