### PR TITLE
Add duplication check for test suites and test cases

### DIFF
--- a/src/main/java/org/openmainframeproject/cobolcheck/exceptions/TestCaseAlreadyExistsException.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/exceptions/TestCaseAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package org.openmainframeproject.cobolcheck.exceptions;
+
+public class TestCaseAlreadyExistsException extends RuntimeException {
+    public TestCaseAlreadyExistsException(String message) {
+        super(message);
+    }
+    public TestCaseAlreadyExistsException(Throwable cause) {
+        super(cause);
+    }
+    public TestCaseAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/openmainframeproject/cobolcheck/exceptions/TestSuiteAlreadyExistsException.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/exceptions/TestSuiteAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package org.openmainframeproject.cobolcheck.exceptions;
+
+public class TestSuiteAlreadyExistsException extends RuntimeException {
+    public TestSuiteAlreadyExistsException(String message) {
+        super(message);
+    }
+    public TestSuiteAlreadyExistsException(Throwable cause) {
+        super(cause);
+    }
+    public TestSuiteAlreadyExistsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Fixes: #217 

This PR enforces a check on Test Suite names and Test Case names so that no two Test Suites can have the same name, and the same for two test cases in the same suite. Also created the respective exception for both the cases.