### PR TITLE
288 Enable COBOL Check to issue warnings/errors when a call statement is not mocked. 

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -64,6 +64,15 @@ cobolcheck.test.program.path = ./
 cobolcheck.test.program.name = CC##99.CBL
 
 #---------------------------------------------------------------------------------------------------------------------
+# if mock of call statements of a paragraph/section under test, are not present in a testcase 
+# then based on this value either error or warning will be raised.
+# Note: When a call statement is inside a section/paragraph, where the section/paragraph is mocked, 
+# then the call statement is considered mocked.
+# Default: false (warning will be raised)
+#---------------------------------------------------------------------------------------------------------------------
+cobolcheck.unmock.call.alerttype.error = false
+
+#---------------------------------------------------------------------------------------------------------------------
 # Path for the generated testsuite parse error log
 # Default: ./
 #---------------------------------------------------------------------------------------------------------------------

--- a/src/main/java/org/openmainframeproject/cobolcheck/exceptions/UnMockedCallStatementException.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/exceptions/UnMockedCallStatementException.java
@@ -1,0 +1,7 @@
+package org.openmainframeproject.cobolcheck.exceptions;
+
+public class UnMockedCallStatementException extends RuntimeException {
+    public UnMockedCallStatementException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
@@ -83,6 +83,10 @@ public class InterpreterController {
         return reader.readStatementAsOneLine();
     }
 
+    public int getCurrentLineNumber() {
+        return reader.getLineNumber();
+    }
+
     // Getting info from reader
     public boolean hasStatementBeenRead() {
         return reader.hasStatementBeenRead();

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockRepository.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/MockRepository.java
@@ -35,6 +35,25 @@ public class MockRepository {
         return false;
     }
 
+    public boolean mockExistsFor(String identifier, String type, List<String> arguments, String testSuiteName, String testCaseName) {
+        for (Mock mock: mocks) {
+            if (mock.getIdentifier().equalsIgnoreCase(identifier) && mock.getType().equals(type)
+                    && mock.getArguments().equals(arguments)){
+                if (mock.getScope() == MockScope.Local){
+                    if (mock.getTestSuiteName().equals(testSuiteName) && mock.getTestCaseName().equals(testCaseName)){
+                        return true;
+                    }
+                }
+                if (mock.getScope() == MockScope.Global){
+                    if (mock.getTestSuiteName().equals(testSuiteName)){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     public Mock getMockFor(String identifier, String type, String testSuite, String testCase, List<String> arguments){
         List<Mock> globalMocks = new ArrayList<>();
         for (Mock mock: mocks) {

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/TestSuiteErrorLog.java
@@ -1,5 +1,6 @@
 package org.openmainframeproject.cobolcheck.features.testSuiteParser;
 
+import org.openmainframeproject.cobolcheck.exceptions.UnMockedCallStatementException;
 import org.openmainframeproject.cobolcheck.services.Config;
 import org.openmainframeproject.cobolcheck.services.Constants;
 import org.openmainframeproject.cobolcheck.services.Messages;
@@ -145,6 +146,21 @@ public class TestSuiteErrorLog {
                         "any construct in the source code" + Constants.NEWLINE + Constants.NEWLINE;
                 outputError(error);
             }
+        }
+    }
+
+    public void logUnMockedCalls(String testSuiteName, String testCaseName, int currentCallLineNumber) {
+        String alertType = Config.getString(Constants.COBOLCHECK_UNMOCKCALL_ALERTTYPE_CONFIG_KEY, "false");
+        String testCaseNameToDisplay = (testCaseName.equals("")) ? "global test case" : "testcase " + testCaseName;
+        if(alertType.equalsIgnoreCase("TRUE")) {
+            throw new UnMockedCallStatementException(
+                Messages.get("ERR033", String.valueOf(currentCallLineNumber), testCaseNameToDisplay, testSuiteName)
+            );
+        }
+        else {
+            Log.warn(
+                Messages.get("WRN009",String.valueOf(currentCallLineNumber), testCaseNameToDisplay, testSuiteName)
+            );
         }
     }
 

--- a/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/services/Constants.java
@@ -100,6 +100,7 @@ public final class Constants {
     public static final String DEFAULT_TEST_PROGRAM_NAME = "CC$$99.CBL";
     public static final String PROCESS_CONFIG_KEY = ".process";
     public static final String COBOLCHECK_PREFIX_CONFIG_KEY = "cobolcheck.prefix";
+    public static final String COBOLCHECK_UNMOCKCALL_ALERTTYPE_CONFIG_KEY = "cobolcheck.unmock.call.alerttype.error";
     public static final String DEFAULT_COBOLCHECK_PREFIX = "UT-";
     public static final String TEST_CODE_PREFIX_PLACEHOLDER = "==UT==";
 

--- a/src/main/resources/org/openmainframeproject/cobolcheck/messages/messages.properties
+++ b/src/main/resources/org/openmainframeproject/cobolcheck/messages/messages.properties
@@ -32,6 +32,7 @@ ERR029 = ERR029: NumericFields.setDataTypeOf() was called with null dataType.
 ERR030 = ERR030: Command line missing program argument '-p programName' .
 ERR031 = ERR031: A test suite with the name %1$s already exists.
 ERR032 = ERR032: A test case with the name %1$s already exists in the test suite %2$s.
+ERR033 = ERR033: Call Statement in Line %1$s of the source code is not mocked in %2$s of testSuite %3$s.
 
 WRN001 = WRN001: No test suite directory for program %1$s was found under directory %2$s.
 WRN002 = WRN002: No test suite files were found under directory %1$s.
@@ -41,6 +42,7 @@ WRN005 = WRN005: Test results input file not found: %1$s. Define in config as te
 WRN006 = WRN006: IOException writing test results to file: %1$s in ProcessOutputWriter.writeProcessOutputToFile(...)
 WRN007 = WRN007: IOException reading test results from current process
 WRN008 = WRN008: Access denied: Could not change permissions for %1$s
+WRN009 = WRN009: Call Statement in Line %1$s of the source code is not mocked in %2$s of testSuite %3$s.
 
 INF001 = INF001: Attempting to load config from %1$s.
 INF002 = INF002: Loaded config successfully from %1$s.


### PR DESCRIPTION
Fixes: #288 