### PR TITLE
Ddh 11915 create alternative temp file for cobol check extension

### DIFF
--- a/vs-code-extension/client/src/extension.ts
+++ b/vs-code-extension/client/src/extension.ts
@@ -32,6 +32,7 @@ export async function activate(context: ExtensionContext) {
 
 	const fileChangedEmitter = new vscode.EventEmitter<vscode.Uri>();
 	
+	// let runCobolCheck_Cmd = vscode.commands.registerCommand('cobolcheck.run', (pathToExpandedProgram : string) => {
 	let runCobolCheck_Cmd = vscode.commands.registerCommand('cobolcheck.run', () => {
 		//Setting loader
 		vscode.window.withProgress({location: vscode.ProgressLocation.Notification, cancellable: true, title: 'Cobol Check running:'}, 
@@ -41,7 +42,15 @@ export async function activate(context: ExtensionContext) {
 
 			//Getting arguments to run
 			let applicationSourceDir = await getConfigurationValueFor(configPath, 'application.source.directory');
-			let argument : string = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, vscode.window.activeTextEditor.document.uri.fsPath);
+			// let argument : string = ''
+			// console.log("Cobol-check extention: pathToExpandedProgram=" + pathToExpandedProgram)	
+			// if(pathToExpandedProgram === undefined) {
+				let argument : string = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, vscode.window.activeTextEditor.document.uri.fsPath);
+			// }
+			// else {
+			// 	argument = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, pathToExpandedProgram);
+			// }
+			// console.log("Cobol-check extention: argument=" + argument)
 			if (argument === null) return;
 
 			progress.report({ message: 'Running tests' })

--- a/vs-code-extension/client/src/extension.ts
+++ b/vs-code-extension/client/src/extension.ts
@@ -32,8 +32,7 @@ export async function activate(context: ExtensionContext) {
 
 	const fileChangedEmitter = new vscode.EventEmitter<vscode.Uri>();
 	
-	// let runCobolCheck_Cmd = vscode.commands.registerCommand('cobolcheck.run', (pathToExpandedProgram : string) => {
-	let runCobolCheck_Cmd = vscode.commands.registerCommand('cobolcheck.run', () => {
+	let runCobolCheck_Cmd = vscode.commands.registerCommand('cobolcheck.run', (pathToExpandedProgram : string) => {
 		//Setting loader
 		vscode.window.withProgress({location: vscode.ProgressLocation.Notification, cancellable: true, title: 'Cobol Check running:'}, 
 		async (progress) => {
@@ -42,15 +41,15 @@ export async function activate(context: ExtensionContext) {
 
 			//Getting arguments to run
 			let applicationSourceDir = await getConfigurationValueFor(configPath, 'application.source.directory');
-			// let argument : string = ''
-			// console.log("Cobol-check extention: pathToExpandedProgram=" + pathToExpandedProgram)	
-			// if(pathToExpandedProgram === undefined) {
-				let argument : string = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, vscode.window.activeTextEditor.document.uri.fsPath);
-			// }
-			// else {
-			// 	argument = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, pathToExpandedProgram);
-			// }
-			// console.log("Cobol-check extention: argument=" + argument)
+			let argument : string = null
+			console.log("Cobol-check extention: pathToExpandedProgram=" + pathToExpandedProgram)	
+			if(pathToExpandedProgram === undefined) {
+				argument = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, vscode.window.activeTextEditor.document.uri.fsPath);
+			}
+			else {
+				argument = getCobolCheckRunArgumentsBasedOnCurrentFile(externalVsCodeInstallationDir, configPath, applicationSourceDir, pathToExpandedProgram);
+			}
+			console.log("Cobol-check extention: argument=" + argument)
 			if (argument === null) return;
 
 			progress.report({ message: 'Running tests' })

--- a/vs-code-extension/client/src/extension.ts
+++ b/vs-code-extension/client/src/extension.ts
@@ -1,4 +1,4 @@
-// The module 'vscode' contains the VS Code extensibility API
+// The module 'vscode' contains the VS Code extensibility API 
 // Import the module and reference it with the alias vscode in your code below
 
 //Include files ved byg/udgivelse?

--- a/vs-code-extension/package.json
+++ b/vs-code-extension/package.json
@@ -8,7 +8,7 @@
         "Snippets"
     ],
     "description": "Extension for running unit tests in Cobol",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "icon": "images/cobol-check-logo-small.png",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Now you can choose to give cobol-check extension a filename of the expanded COBOL code. Then it won't expect to find it in an open Window (tab) in VScode.