### PR TITLE
Preserve linenumbers from original source to enable a more robust met…

### DIFF
--- a/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/interpreter/InterpreterController.java
@@ -238,7 +238,7 @@ public class InterpreterController {
         }
 
         // Current line might change from when it was originally read
-        return reader.getCurrentLine().getUnNumberedString();
+        return reader.getCurrentLine().getOriginalString();
     }
 
     public void closeReader() {
@@ -606,7 +606,7 @@ public class InterpreterController {
     public void addSectionOrParagraphLine(){
         if(Interpreter.shouldLineBeStubbed(reader.getCurrentLine(), reader.getState()))
             sectionOrParagraph.addLine(StringHelper.stubLine(reader.getCurrentLine().getUnNumberedString(), stubTag));
-        else sectionOrParagraph.addLine(reader.getCurrentLine().getUnNumberedString());
+        else sectionOrParagraph.addLine(reader.getCurrentLine().getOriginalString());
     }
 
     public void addSectionOrParagraphLine(String line){

--- a/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/CobolGenerator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/features/testSuiteParser/CobolGenerator.java
@@ -16,23 +16,6 @@ public class CobolGenerator {
 
 
 
-    static List<String> generateSectionLines(String identifier, List<String> commentLines, List<String> bodyLines){
-        List<String> lines = new ArrayList<>();
-        lines.add(String.format(SECTION_HEADER_FORMAT, identifier));
-        if (commentLines != null)
-            lines.addAll(commentLines);
-        if (bodyLines != null) {
-            lines.addAll(bodyLines);
-            // Check if the last line in bodyLines ends with a period
-            if (!bodyLines.get(bodyLines.size() - 1).endsWith(".")) {
-                lines.add(ENDING_PERIOD);
-            }
-        } else {
-            // If bodyLines is null, add ENDING_PERIOD
-            lines.add(ENDING_PERIOD);
-        }
-        return lines;
-    }
 
     static List<String> generateParagraphLines(String identifier, List<String> commentLines, List<String> bodyLines){
         List<String> lines = new ArrayList<>();

--- a/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
+++ b/src/main/java/org/openmainframeproject/cobolcheck/workers/Generator.java
@@ -154,8 +154,10 @@ public class Generator {
             }
         }
         return sourceLine;
+
     }
 
+    
     /**
      * Writes the given line to the output file. If a multiline statement has been read, this will
      * be written instead (this statement will include the line). Comments out lines and statements
@@ -248,6 +250,10 @@ public class Generator {
     private void echoingSourceLineToOutput(String sourceLine){
         try{
             if(interpreter.isInsideSectionOrParagraphMockBody()){
+                // Avoid giving mocked section ending period line numbers, as they would be duplicates
+                if (sourceLine.length() > 6 && sourceLine.substring(6).trim().equals(".")) {
+                    sourceLine = "      " + sourceLine.substring(6);
+                }
                 interpreter.addSectionOrParagraphLine();
             }
             sourceLine = tryInsertEndEvaluateAtMockedCompomentEnd(sourceLine);


### PR DESCRIPTION
…hod to generate code coverage reports